### PR TITLE
Add step to disable WiFi

### DIFF
--- a/src/configure-nilrt-snac
+++ b/src/configure-nilrt-snac
@@ -150,6 +150,10 @@ disable_wifi() {
 install cfg80211 /bin/true
 install mac80211 /bin/true
 EOT
+
+	# unload the modules if they are already loaded
+	# This will most likely error so send the output to /dev/null
+	rmmod cfg80211 mac80211 >/dev/null 2>&1
 }
 
 

--- a/src/configure-nilrt-snac
+++ b/src/configure-nilrt-snac
@@ -140,6 +140,18 @@ remove_niauth() {
 	trap - EXIT
 }
 
+disable_wifi() {
+	log INFO Disabling WiFi...
+	cat <<EOT >/etc/modprobe.d/snac_blacklist.conf
+# Do not allow WiFi connections
+# We cannot use the blacklist keyword because they will still be loaded
+# when another module depends on them. This will prevent the modules from
+# being loaded along with any modules that depends on them.
+install cfg80211 /bin/true
+install mac80211 /bin/true
+EOT
+}
+
 
 ## MAIN
 # runtime environment safety checks
@@ -175,6 +187,8 @@ opkg remove '*xfce4*-locale-ja*'  # where do these come from !?!
 install_cryptsetup
 
 configure_ntp
+
+disable_wifi
 
 syslog notice SNAC configuration completed.
 exit 0

--- a/src/configure-nilrt-snac
+++ b/src/configure-nilrt-snac
@@ -142,14 +142,14 @@ remove_niauth() {
 
 disable_wifi() {
 	log INFO Disabling WiFi...
-	cat <<EOT >/etc/modprobe.d/snac_blacklist.conf
+	cat <<EOF >/etc/modprobe.d/snac_blacklist.conf
 # Do not allow WiFi connections
 # We cannot use the blacklist keyword because they will still be loaded
 # when another module depends on them. This will prevent the modules from
 # being loaded along with any modules that depends on them.
 install cfg80211 /bin/true
 install mac80211 /bin/true
-EOT
+EOF
 
 	# unload the modules if they are already loaded
 	# This will most likely error so send the output to /dev/null

--- a/src/nilrt-snac
+++ b/src/nilrt-snac
@@ -89,7 +89,8 @@ command=${positionals[0]}
 cmd_configure() {
 	echo WARNING '!! THIS TOOL IS IN-DEVELOPMENT AND APPROPRIATE ONLY FOR DEVELOPER TESTING !!'
 	echo WARNING '!! Running this tool will irreversibly alter the state of your system.    !!'
-
+	echo WARNING '!! If you are accessing your system using WiFi, you will lose connection. !!'
+	
 	# prompt for consent
 	local consent=false
 	if $yes; then


### PR DESCRIPTION
### Summary of Changes

Add a blacklist file in /etc/modprobe.d that will prevent `cfg80211` and `mac80211` kernel modules from loading. This is to prevent any WiFi networks from working


### Justification

US#2816965 - [SNAC Auth] Remove wireless driver from NILRT via SNAC configuration tool


### Testing

Manually add a file with the same contents and verified the wlan0 interface was gone after rebooting. Removing the file allowed wlan0 to reappear


### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
