### PR TITLE
Install a nilrt-snac-conflicts meta-package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # make-generated files
 /nilrt-snac-*.tar.gz
+/src/nilrt-snac-conflicts/*.tar.gz
+/src/nilrt-snac-conflicts/*.ipk

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ sbindir ?= $(exec_prefix)/sbin
 
 SRC_FILES = \
 	src/configure-nilrt-snac \
+	src/nilrt-snac-conflicts/control \
 	src/nilrt-snac \
 	src/util.sh \
 
@@ -33,23 +34,35 @@ DIST_FILES = \
 	Makefile \
 
 
+
+# REAL TARGETS #
+################
+
+$(PACKAGE)-$(VERSION).tar.gz : $(DIST_FILES)
+	tar -czf $@ $(DIST_FILES)
+
+
+src/nilrt-snac-conflicts/nilrt-snac-conflicts.ipk :
+	make -C src/nilrt-snac-conflicts $(@F)
+
+
 # PHONY TARGETS #
 #################
 
 .PHONY : all clean dist install uninstall
 
-all :
-	@echo "Nothing to build. All source files are architecture-independent."
+all : nilrt-snac-conflicts
 
 
 clean :
 	rm -f ./$(PACKAGE)-*.tar.gz
+	make -C src/nilrt-snac-conflicts clean
 
 
 dist : $(PACKAGE)-$(VERSION).tar.gz
 
 
-install : $(DIST_FILES)
+install : $(DIST_FILES) src/nilrt-snac-conflicts/nilrt-snac-conflicts.ipk
 	mkdir -p $(DESTDIR)$(sbindir)
 	install -o 0 -g 0 --mode=0755 -t "$(DESTDIR)$(sbindir)" \
 		src/nilrt-snac
@@ -64,15 +77,13 @@ install : $(DIST_FILES)
 		LICENSE \
 		README.md
 
+	# install conflicts IPK
+	mkdir -p $(DESTDIR)$(datarootdir)/$(PACKAGE)
+	install --mode=0644 -t "$(DESTDIR)$(datarootdir)/$(PACKAGE)" \
+		src/nilrt-snac-conflicts/nilrt-snac-conflicts.ipk
+
 
 uninstall :
 	rm -vf $(DESTDIR)$(sbindir)/nilrt-snac
 	rm -rvf $(DESTDIR)$(libdir)/$(PACKAGE)
 	rm -rvf $(DESTDIR)$(docdir)/$(PACKAGE)
-
-
-# REAL TARGETS #
-################
-
-$(PACKAGE)-$(VERSION).tar.gz : $(DIST_FILES)
-	tar -czf $@ $(DIST_FILES)

--- a/src/configure-nilrt-snac
+++ b/src/configure-nilrt-snac
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 SCRIPT_ROOT="$(realpath $(dirname ${BASH_SOURCE}))"
+PREFIX_ROOT="$(realpath ${SCRIPT_ROOT}/../../)"
 source "${SCRIPT_ROOT}/util.sh"
 
 ## CONSTANTS
@@ -133,6 +134,7 @@ remove_niauth() {
 
 	#sed -i '/Essential: yes/d' /var/lib/opkg/status
 	opkg remove --force-removal-of-essential-packages --force-depends ni-auth
+	opkg install "${PREFIX_ROOT}/share/nilrt-snac/nilrt-snac-conflicts.ipk"
 	passwd -d root
 	log DEBUG root account password deleted.
 

--- a/src/nilrt-snac-conflicts/Makefile
+++ b/src/nilrt-snac-conflicts/Makefile
@@ -1,0 +1,19 @@
+.DEFAULT_GOAL := all
+.PHONY : all clean
+
+
+all : nilrt-snac-conflicts.ipk
+
+
+clean :
+	rm -f *.tar.gz
+	rm -f *.ipk
+
+
+control.tar.gz : control
+	tar -czf $@ $<
+
+
+nilrt-snac-conflicts.ipk : control.tar.gz
+	tar -czf data.tar.gz -T /dev/null  # make empty data segment
+	ar rc $@ $^ data.tar.gz

--- a/src/nilrt-snac-conflicts/control
+++ b/src/nilrt-snac-conflicts/control
@@ -1,0 +1,4 @@
+Package: nilrt-snac-conflicts
+Architecture: all
+Version: 0.1
+Conflicts: ni-auth


### PR DESCRIPTION
### Summary of Changes

Some parts of the SNAC configuration prohibit the installation of certain packages like ni-auth or xserver. But these packages might accidentally get reinstalled as dependencies of other package installations.

As a protection against that happening, construct a meta-package called nilrt-snac-conflicts, that contains no data, but conflicts with prohibited packages. Install it to the system after uninstalling the bad packages, to keep them from getting reinstalled.


### Justification

[AB#2791297](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2791297)

The [nilrt-snac configure script](https://github.com/amstewart/nilrt-snac/blob/master/src/configure-nilrt-snac) de-installs ni-auth as one of its first steps, in order to keep the niauth database from conflicting with subsequent steps. In one subsequent step, the script downloads and installs the wireguard-tools.deb from the debian package repos. When opkg installs wireguard-tools, it somehow notices that ni-auth was removed and reinstalls it - undoing all the work.


### Testing

* [x] Installed this patchset repo to a NILRT 24.5 BSI and ran `make install`. Everything installs correctly and the `nilrt-snac configure` script works.
* [x] After running, the `ni-auth` package is still listed as `uninstalled` and the `nilrt-snac-conflicts` IPK is installed.
* [x] Trying to install `ni-auth` results in an opkg solution conflict, referencing the conflicts-IPK.
```
admin@NI-cRIO-903x-VM-18b27262:~/nilrt-snac# opkg install ni-auth
 * Solver encountered 1 problem(s):
 * Problem 1/1:
 *   - package nilrt-snac-conflicts-0.1.all conflicts with ni-auth provided by ni-auth-24.3.0.49350-0+f198.core2-64
 *   - conflicting requests
 *   - problem with installed package nilrt-snac-conflicts-0.1.all
 * 
 * Solution 1:
 *   - allow deinstallation of nilrt-snac-conflicts-0.1.all


 * Solution 2:
 *   - do not ask to install a package providing ni-auth
```


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
* After submission, I will cherry-pick this fix into the v0.1 stable branch.