### PR TITLE
.github: add PR workflow to check signoffs

### DIFF
--- a/.github/workflows/check_signoffs.sh
+++ b/.github/workflows/check_signoffs.sh
@@ -1,0 +1,38 @@
+# Check commits in this pull request for Signed-off-by trailers, and assure that
+# the committer has given his signoff.
+set -e
+
+# Get the base branch reference from the PR
+REMOTE=${REMOTE:-origin}
+BASE_BRANCH=${BASE_BRANCH:-master}
+
+# Fetch the base branch
+git fetch $REMOTE $BASE_BRANCH
+
+# Get the list of commits in the pull request against the base branch
+commits=$(git rev-list --reverse $REMOTE/$BASE_BRANCH..HEAD)
+
+# Check each commit for Signed-off-by trailer
+test_signed_off_ok=true
+for commit in $commits; do
+	
+	signoffs=$(git show --format="%(trailers:key=Signed-off-by,valueonly=true)" -s $commit)
+	#echo -e "\tsignoffs=${signoffs}"
+	committer=$(git show --format='%cN <%cE>' -s $commit)
+	#echo -e "\tcommitter=${committer}"
+	echo -n "Checking commit $commit..."
+	if ! grep -q "$committer"; then
+		test_signed_off_ok=false
+		echo " ERROR"
+		echo "ERROR: No signed-off-by in $(git show --format='%H %s' -s $commit)"
+	else
+		echo " OK"
+	fi <<<$signoffs
+done
+
+if $test_signed_off_ok; then
+	echo "All commits have Signed-off-by trailers."
+	exit 0
+else
+	exit 1
+fi

--- a/.github/workflows/pr-commit-check.yml
+++ b/.github/workflows/pr-commit-check.yml
@@ -1,0 +1,20 @@
+name: PR Check Commit Policies
+
+on: [pull_request]
+
+jobs:
+  check-signed-off:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # Fetch all history to ensure we can compare with the base branch
+        ref: ${{ github.event.pull_request.head.sha }}  # checkout the PR HEAD, instead of a merge commit
+
+    - name: Verify commit sign-offs
+      run: |
+        export REMOTE=origin
+        export BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
+        bash .github/workflows/check_signoffs.sh


### PR DESCRIPTION
### Summary of Changes

By repo policy, all commits should have a signed-off-by trailer. Add a Github PR to check for this policy.


### Justification

This repo's policy requires commits to be signed. This pipeline will help devs remember to add their signoffs.


### Testing

Tested on my repo [here](https://github.com/amstewart/nilrt-snac/pull/1).

Failed test output looks like [this](https://github.com/amstewart/nilrt-snac/actions/runs/10410594541/job/28832767711?pr=1).

```
 Checking commit 18de7b3bb86cea0dd0bb8c37df5b7c7b21cc2cd1... OK
Checking commit 905268475647eb897eb9cca9ccb9a8119f2ae64b... ERROR
ERROR: No signed-off-by in 905268475647eb897eb9cca9ccb9a8119f2ae64b .github: add script
Checking commit 1519c180bf76894c0c2b67d5eea92d49d5d0161f... ERROR
ERROR: No signed-off-by in 1519c180bf76894c0c2b67d5eea92d49d5d0161f squashme
Checking commit 6fa20486dfb2b9e9f400141b7d430a037aa0e034... ERROR
ERROR: No signed-off-by in 6fa20486dfb2b9e9f400141b7d430a037aa0e034 squashme
Checking commit 4b72e07c8d53213539adeeb560558ff7eea28d01... ERROR
ERROR: No signed-off-by in 4b72e07c8d53213539adeeb560558ff7eea28d01 squashme
Checking commit 96dad11ead8916e61c1acc781b375cabbbdc4bb9... ERROR
ERROR: No signed-off-by in 96dad11ead8916e61c1acc781b375cabbbdc4bb9 squashme
```

Successful test output looks like [this](https://github.com/amstewart/nilrt-snac/actions/runs/10410614544/job/28832825589?pr=1).

```
 Checking commit 090941bdffb117dcb5ec7bf82851728b32568503... OK
```


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
