### PR TITLE
configure-nilrt-snac: Add password quality enforcement

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * The `configure` operation now disables WIFI interfaces. (#2)
 * The `configure` operation now installs a `nilrt-snac-conflicts` meta-package, so that the tool can forbid re-installation of non-compliant packages. (#5)
+* The `configure` operation now installs `libpwquality` and enables password quality checks. (#11)
 
 ### Changed
 

--- a/src/configure-nilrt-snac
+++ b/src/configure-nilrt-snac
@@ -172,6 +172,17 @@ remove_niauth() {
 	trap - EXIT
 }
 
+enable_pwquality() {
+	log INFO Enabling password quality checks...
+	log INFO Enabling password history...
+	sed -i 's/^\(password.*pam_unix.so.*\)$/\1 remember=5/' /etc/pam.d/common-password
+	log INFO Enabling password complexity using libpwquality...
+	cat <<-EOF >>/etc/pam.d/common-password
+		# Additional check for password complexity
+		password	requisite	pam_pwquality.so retry=3
+	EOF
+}
+
 disable_wifi() {
 	log INFO Disabling WiFi...
 	cat <<EOF >/etc/modprobe.d/snac_blacklist.conf
@@ -223,6 +234,8 @@ opkg remove '*xfce4*-locale-ja*'  # where do these come from !?!
 install_cryptsetup
 
 configure_ntp
+
+enable_pwquality
 
 disable_wifi
 


### PR DESCRIPTION
### Summary of Changes

* Add setting to pam_unix.so to remember 5 passwords
* Add pam_pwquality.so to enforce password complexity
  * Uses installed pwquality.conf for settings
* Add statement in "Added" section of README.md

### Justification

[AB#2817094](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2817094)

### Testing

* Using ipk from ni/meta-nilrt#717, verified settings were enforced with `pwscore`

### Procedure

* [X] This PR: changes user-visible behavior, fixes a bug, or impacts the project's security profile; and so it includes a [CHANGELOG](https://github.com/ni/nilrt-snac/blob/master/docs/CHANGELOG.md) note.
* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
