### PR TITLE
Ignore failure of rmmod cfg80211 mac80211 command

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* The `configure` operation now disables WIFI interfaces. (#2)
+* The `configure` operation now disables WIFI interfaces. (#2, #13)
 * The `configure` operation now installs a `nilrt-snac-conflicts` meta-package, so that the tool can forbid re-installation of non-compliant packages. (#5)
 
 ### Changed

--- a/src/configure-nilrt-snac
+++ b/src/configure-nilrt-snac
@@ -185,7 +185,9 @@ EOF
 
 	# unload the modules if they are already loaded
 	# This will most likely error so send the output to /dev/null
+	set +e
 	rmmod cfg80211 mac80211 >/dev/null 2>&1
+	set -e
 }
 
 


### PR DESCRIPTION
### Summary of Changes

Ignore failure of the `rmmod cfg80211 mac80211` command in `disable_wifi`.


### Justification

The `rmmod cfg80211 mac80211` is expected to usually fail. We want the script to complete regardless the outcome.


### Testing

Successfully run `nilrt-snac configure` on a NILRT VM after modifying `configure-nilrt-snac`.

### Procedure

* [x] This PR: changes user-visible behavior, fixes a bug, or impacts the project's security profile; and so it includes a [CHANGELOG](https://github.com/ni/nilrt-snac/blob/master/docs/CHANGELOG.md) note.
* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
