### PR TITLE
Makefile: fix build issue with 'all' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ src/nilrt-snac-conflicts/nilrt-snac-conflicts.ipk :
 
 .PHONY : all clean dist install uninstall
 
-all : nilrt-snac-conflicts
+all : src/nilrt-snac-conflicts/nilrt-snac-conflicts.ipk
 
 
 clean :
@@ -65,7 +65,7 @@ clean :
 dist : $(PACKAGE)-$(VERSION).tar.gz
 
 
-install : $(DIST_FILES) src/nilrt-snac-conflicts/nilrt-snac-conflicts.ipk
+install : all $(DIST_FILES)
 	mkdir -p $(DESTDIR)$(sbindir)
 	install -o 0 -g 0 --mode=0755 -t "$(DESTDIR)$(sbindir)" \
 		src/nilrt-snac


### PR DESCRIPTION
### Summary of Changes

The Makefile 'all' target attempts to depend upon the non-existent 'nilrt-snac-conflicts' PHONY target, causing a Make failure.

Instead, have 'all' depend upon the real IPK target from nilrt-snac-conflicts, and make install depend on 'all' to inherit the same dependencies.


### Justification

```bash
$ make
make: *** No rule to make target 'nilrt-snac-conflicts', needed by 'all'.  Stop.
```

Breaks local installation on NILRT and the compile stage of an OE recipe build for this project.


### Testing

* [x] `make`, `make all`, and `make install` now all work on my build machine.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
