### PR TITLE
nilrt_snac: fix misspelled enum

### DIFF
--- a/nilrt_snac/_pre_reqs.py
+++ b/nilrt_snac/_pre_reqs.py
@@ -11,7 +11,7 @@ from nilrt_snac import Errors, SNACError, logger
 def _check_euid_root():
     print("Checking EUID")
     if os.geteuid() != 0:
-        raise SNACError("This script must be run as root.", Errors.EX_BAD_ENVIRONEMNT)
+        raise SNACError("This script must be run as root.", Errors.EX_BAD_ENVIRONMENT)
 
 
 # Check that iptables is available.
@@ -39,13 +39,13 @@ def _check_iptables():
 def _check_runmode():
     safe_mode = pathlib.Path("/etc/natinst/safemode")
     if safe_mode.exists():
-        raise SNACError("This script cannot be run in safe mode.", Errors.EX_BAD_ENVIRONEMNT)
+        raise SNACError("This script cannot be run in safe mode.", Errors.EX_BAD_ENVIRONMENT)
 
 
 # Check that the script is running on NI LinuxRT
 def _check_nilrt():
     if get_distro() != "nilrt":
-        raise SNACError("This script must be run on a NILRT system.", Errors.EX_BAD_ENVIRONEMNT)
+        raise SNACError("This script must be run on a NILRT system.", Errors.EX_BAD_ENVIRONMENT)
 
 
 def verify_prereqs():  # noqa: D103 - Missing docstring in public function (auto-generated noqa)


### PR DESCRIPTION
Several of the _pre_reqs system checks attempt to throw SNACErrors coded as EX_BAD_ENVIRONMENT, if they fail. But 'ENVIRONMENT' is misspelled, and so these throw AttributeErrors.

Fixup the spelling.


### Testing

None; trivial.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
