### PR TITLE
.github: add PR test

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1,0 +1,45 @@
+name: PR Testing
+
+on: [pull_request]
+
+jobs:
+  make-workflows:
+    runs-on: ubuntu-latest
+
+    env:
+      DESTDIR: /tmp/nilrt-snac
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history so that git-describe works
+      - run: make all
+      - name: make install
+        run: |
+          make install
+          tree -ap "${DESTDIR}"
+      - name: make uninstall
+        run: |
+          make uninstall
+          tree -ap "${DESTDIR}"
+          
+          leftover_files=false
+          find "${DESTDIR}" -type f >./leftover_files
+          
+          while read file; do
+            echo "ERROR: leftover file: ${file}"
+            leftover_files=true
+          done <./leftover_files
+
+          if $leftover_files; then
+            echo "ERROR: uninstall did not remove all files."
+            cat ./leftover_files
+            exit 1
+          else
+            echo "OK"
+          fi
+      - name: make dist
+        run: |
+          make dist
+          tar --list -f ./nilrt-snac-*.tar.gz


### PR DESCRIPTION
Add a PR testing workflow where we can start to add autotests.

At the moment, it just checks that the Makefile workflows function, but it could be expanded to include unit tests and (if we get a NILRT runner) integration tests.


### Testing

* [x] Tested this on [my own repo](https://github.com/amstewart/nilrt-snac/actions/workflows/pr-test.yml) with a branch based on #22.


### Procedure

* [x] Blocked on #22. This pipeline [will fail](https://github.com/amstewart/nilrt-snac/actions/runs/10836835663/job/30071454244) until its changes are in.
* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
