### PR TITLE
Install libpwquality when configuring pwquality

### DIFF
--- a/nilrt_snac/_configs/_pwquality_config.py
+++ b/nilrt_snac/_configs/_pwquality_config.py
@@ -5,16 +5,18 @@ from nilrt_snac._configs._base_config import _BaseConfig
 from nilrt_snac._configs._config_file import _ConfigFile
 
 from nilrt_snac import logger
+from nilrt_snac.opkg import opkg_helper
 
 
 class _PWQualityConfig(_BaseConfig):
     def __init__(self):
-        pass
+        self._opkg_helper = opkg_helper
 
     def configure(self, args: argparse.Namespace) -> None:
         print("Configuring Password quality...")
         config_file = _ConfigFile("/etc/pam.d/common-password")
         dry_run: bool = args.dry_run
+        self._opkg_helper.install("libpwquality")
 
         if not config_file.contains("remember=5"):
             config_file.update(r"(password.*pam_unix.so.*)", r"\1 remember=5")
@@ -34,6 +36,9 @@ class _PWQualityConfig(_BaseConfig):
         print("Verifying Password quality...")
         config_file = _ConfigFile("/etc/pam.d/common-password")
         valid = True
+        if not self._opkg_helper.is_installed("libpwquality"):
+            valid = False
+            logger.error("MISSING: libpwquality not installed")
         if not config_file.contains("remember=5"):
             valid = False
             logger.error("MISSING: 'remember=5' for pam_unix.so configuration")


### PR DESCRIPTION
### Summary of Changes

* Install `libpwquality` as part of configuring pwquality
  * We rely on default settings


### Justification

Needed to correctly enforce password quality


### Testing

* When not installed, changing a password fails since the PAM module can not be loaded
* When installed, changing a password enforces the given requirements


### Procedure

* [ ] ~~This PR: changes user-visible behavior, fixes a bug, or impacts the project's security profile; and so it includes a [CHANGELOG](https://github.com/ni/nilrt-snac/blob/master/docs/CHANGELOG.md) note.~~
* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
