### PR TITLE
nilrt-snac: remove niacctbase-sudo package

### DIFF
--- a/nilrt_snac/_configs/_niauth_config.py
+++ b/nilrt_snac/_configs/_niauth_config.py
@@ -15,6 +15,7 @@ class _NIAuthConfig(_BaseConfig):
         print("Removing NIAuth...")
         dry_run: bool = args.dry_run
         self._opkg_helper.remove("ni-auth", force_essential=True, force_depends=True)
+        self._opkg_helper.remove("niacctbase-sudo")
         if not self._opkg_helper.is_installed("nilrt-snac-conflicts"):
             self._opkg_helper.install(str(SNAC_DATA_DIR / "nilrt-snac-conflicts.ipk"))
 
@@ -28,6 +29,9 @@ class _NIAuthConfig(_BaseConfig):
         if self._opkg_helper.is_installed("ni-auth"):
             valid = False
             logger.error("FOUND: ni-auth installed")
+        if self._opkg_helper.is_installed("niacctbase-sudo"):
+            valid = False
+            logger.error("FOUND: niacctbase-sudo installed")
         if not self._opkg_helper.is_installed("nilrt-snac-conflicts"):
             valid = False
             logger.error("MISSING: nilrt-snac-conflicts not installed")

--- a/src/nilrt-snac-conflicts/control
+++ b/src/nilrt-snac-conflicts/control
@@ -1,4 +1,4 @@
 Package: nilrt-snac-conflicts
 Architecture: all
 Version: 0.1
-Conflicts: ni-auth
+Conflicts: ni-auth, niacctbase-sudo


### PR DESCRIPTION
### Summary of Changes

remove the `niacctbase-sudo` package when configuring a SNAC target


### Justification

The `niacctbase-sudo` package installs a sudo configuration file that gives special privileges to any account named `admin`.


### Testing

None.


### Procedure

* [ ] This PR: changes user-visible behavior, fixes a bug, or impacts the project's security profile; and so it includes a [CHANGELOG](https://github.com/ni/nilrt-snac/blob/master/docs/CHANGELOG.md) note.
* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
