### PR TITLE
Set correct permissions on tmux config files

### DIFF
--- a/nilrt_snac/_configs/_tmux_config.py
+++ b/nilrt_snac/_configs/_tmux_config.py
@@ -15,7 +15,9 @@ class _TmuxConfig(_BaseConfig):
     def configure(self, args: argparse.Namespace) -> None:
         print("Configuring tmux...")
         snac_config_file = _ConfigFile("/usr/share/tmux/conf.d/snac.conf")
+        snac_config_file.chmod(0o644)
         profile_file = _ConfigFile("/etc/profile.d/tmux.sh")
+        profile_file.chmod(0o644)
         dry_run: bool = args.dry_run
         self._opkg_helper.install("tmux")
 


### PR DESCRIPTION
### Summary of Changes

Fix file perpissions of tmux config files for non-root users


### Justification

Non-root users are not using tmux properly after `nilrt-snac configure`. 


### Testing

After change, non-root (both in and not in sudoers) now properly use tmux when logging int.


### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
