### PR TITLE
_firewall_config: add

### DIFF
--- a/nilrt_snac/_configs/__init__.py
+++ b/nilrt_snac/_configs/__init__.py
@@ -4,6 +4,7 @@ from nilrt_snac._configs._base_config import _BaseConfig
 from nilrt_snac._configs._console_config import _ConsoleConfig
 from nilrt_snac._configs._cryptsetup_config import _CryptSetupConfig
 from nilrt_snac._configs._faillock_config import _FaillockConfig
+from nilrt_snac._configs._firewall_config import _FirewallConfig
 from nilrt_snac._configs._niauth_config import _NIAuthConfig
 from nilrt_snac._configs._ntp_config import _NTPConfig
 from nilrt_snac._configs._opkg_config import _OPKGConfig
@@ -30,4 +31,5 @@ CONFIGS: List[_BaseConfig] = [
     _TmuxConfig(),
     _PWQualityConfig(),
     _SudoConfig(),
+    _FirewallConfig(),
 ]

--- a/nilrt_snac/_configs/_firewall_config.py
+++ b/nilrt_snac/_configs/_firewall_config.py
@@ -1,0 +1,103 @@
+import argparse
+import subprocess
+
+from nilrt_snac._configs._base_config import _BaseConfig
+
+from nilrt_snac import logger
+from nilrt_snac.opkg import opkg_helper
+
+def _cmd(*args: str):
+    "Syntactic sugar for firewall-cmd -q."
+    subprocess.run(["firewall-cmd", "-q"] + list(args), check=True)
+
+def _offlinecmd(*args: str):
+    "Syntactic sugar for firewall-offline-cmd -q."
+    subprocess.run(["firewall-offline-cmd", "-q"] + list(args), check=True)
+
+def _check_target(policy: str, expected: str = "REJECT") -> bool:
+    "Verifies firewall-cmd --policy=POLICY --get-target matches what is expected."
+
+    actual: str = subprocess.getoutput(
+        f"firewall-cmd --permanent --policy={policy} --get-target")
+    if expected == actual:
+        return True
+    logger.error(f"ERROR: policy {policy} target: expected {expected}, observed {actual}")
+    return False
+
+
+class _FirewallConfig(_BaseConfig):
+    def __init__(self):
+        self._opkg_helper = opkg_helper
+
+    def configure(self, args: argparse.Namespace) -> None:
+        print("Configuring firewall...")
+        dry_run: bool = args.dry_run
+        if dry_run:
+            return
+
+        # nftables installed via deps
+        self._opkg_helper.install("firewalld")
+        self._opkg_helper.install("firewalld-offline-cmd")
+        self._opkg_helper.install("firewalld-log-rotate")
+
+        _offlinecmd("--reset-to-defaults")
+
+        _offlinecmd("--zone=work", "--add-interface=wglv0")
+        _offlinecmd("--zone=work", "--remove-forward")
+        _offlinecmd("--zone=public", "--remove-forward")
+
+        _offlinecmd("--new-policy=work-in")
+        _offlinecmd("--policy=work-in", "--add-ingress-zone=work")
+        _offlinecmd("--policy=work-in", "--add-egress-zone=HOST")
+        _offlinecmd("--policy=work-in", "--add-service=ssh", "--add-service=mdns")
+        _offlinecmd("--policy=work-in", "--set-target=REJECT")
+
+        _offlinecmd("--new-policy=work-out")
+        _offlinecmd("--policy=work-out", "--add-ingress-zone=HOST")
+        _offlinecmd("--policy=work-out", "--add-egress-zone=work")
+        _offlinecmd("--policy=work-out", "--add-service=ssh",
+                        "--add-service=http",
+                        "--add-service=https")
+        _offlinecmd("--policy=work-out", "--set-target=REJECT")
+
+        _offlinecmd("--new-policy=public-in")
+        _offlinecmd("--policy=public-in", "--add-ingress-zone=public")
+        _offlinecmd("--policy=public-in", "--add-egress-zone=HOST")
+        _offlinecmd("--policy=public-in", "--add-service=ssh",
+                        "--add-service=wireguard")
+        _offlinecmd("--policy=public-in", "--set-target=REJECT")
+
+        _offlinecmd("--new-policy=public-out")
+        _offlinecmd("--policy=public-out", "--add-ingress-zone=HOST")
+        _offlinecmd("--policy=public-out", "--add-egress-zone=public")
+        _offlinecmd("--policy=public-out",  "--add-service=dhcp",
+                        "--add-service=dhcpv6",
+                        "--add-service=http",
+                        "--add-service=https",
+                        "--add-service=wireguard",
+                        "--add-service=dns")
+        _offlinecmd("--policy=public-out", "--set-target=REJECT")
+
+        _cmd("--reload")
+
+    def verify(self, args: argparse.Namespace) -> bool:
+        print("Verifying firewall configuration...")
+        valid: bool = True
+
+        try:
+            pid: int = int(subprocess.getoutput("pidof -x /usr/sbin/firewalld"))
+        except ValueError:
+            logger.error(f"MISSING: running firewalld")
+            valid = False
+
+        try:
+            _cmd("--check-config")
+        except FileNotFoundError:
+            logger.error(f"MISSING: firewall-cmd")
+            valid = False
+
+        valid = _check_target("work-in") and valid
+        valid = _check_target("work-out") and valid
+        valid = _check_target("public-in") and valid
+        valid = _check_target("public-out") and valid
+        return valid


### PR DESCRIPTION
Install firewalld and set up a default configuration which allows incoming ssh and wireguard and precious little else. Outgoing traffic permits http, https, wireguard, DHCP. wireguard interface is in "work" zone, everything else is in "public".

### Testing

Manually verified that both incoming and outgoing rules are being applied. Autotesting is currently TBD.

`nilrt-snac verify`, before configure:

```
Verifying firewall configuration...
(   57) ERROR nilrt_snac.verify: MISSING: running firewalld
(   57) ERROR nilrt_snac.verify: MISSING: firewall-cmd
(   57) ERROR nilrt_snac._check_target: ERROR: policy work-in target: expected REJECT, observed /bin/sh: line 1: firewall-cmd: command not found
(   58) ERROR nilrt_snac._check_target: ERROR: policy work-out target: expected REJECT, observed /bin/sh: line 1: firewall-cmd: command not found
(   59) ERROR nilrt_snac._check_target: ERROR: policy public-in target: expected REJECT, observed /bin/sh: line 1: firewall-cmd: command not found
(   59) ERROR nilrt_snac._check_target: ERROR: policy public-out target: expected REJECT, observed /bin/sh: line 1: firewall-cmd: command not found
```

`nilrt-snac configure`:
```
Configuring firewall...
```

`nilrt-snac verify`:
```
Verifying firewall configuration...
```


### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
