### PR TITLE
nilrt-snac configure: avoid side effects when setting a weak password

### DIFF
--- a/nilrt_snac/_configs/_pwquality_config.py
+++ b/nilrt_snac/_configs/_pwquality_config.py
@@ -21,12 +21,13 @@ class _PWQualityConfig(_BaseConfig):
         if not config_file.contains("remember=5"):
             config_file.update(r"(password.*pam_unix.so.*)", r"\1 remember=5")
         if not config_file.contains("password.*requisite.*pam_pwquality.so.*retry=3"):
-            config_file.add(
+            config_file.update(
+                r"(.*here are the per-package modules.*)",
                 textwrap.dedent(
-                    """
-                    # Additional check for password complexity
+                    r"""
+                    # check for password complexity
                     password	requisite	pam_pwquality.so retry=3
-                    """
+                    \1"""
                 )
             )
 


### PR DESCRIPTION
### Summary of Changes

move the pam_pwquality check to higher in the PAM stack


### Justification

Prior to this change, we're putting the pam_pwquality check at the bottom of `common-password`. Due to the way that PAM configuration stacking works, this means that when you try to change a password, say using `chpasswd`, to a weak password, the following happens:

- `chpasswd` returns an error code indicating failure
- `chpasswd` emits a message to stderr about which requirement failed to be met
- the password gets changed to the weak password

The first two are desirable, while the third is not. This PR removes this undesirable side effect when the user provides a weak password.


### Testing

I ran `nilrt-snac configure`, then attempted to change a user's password to a weak password with `chpasswd`, then validated that the user's password did not change. For reference, here is the resulting `common-password`:

```text
~# cat /etc/pam.d/common-password
#
# /etc/pam.d/common-password - password-related modules common to all services
#
# This file is included from other service-specific PAM config files,
# and should contain a list of modules that define the services to be
# used to change user passwords.  The default is pam_unix.

# Explanation of pam_unix options:
#
# The "sha512" option enables salted SHA512 passwords.  Without this option,
# the default is Unix crypt.  Prior releases used the option "md5".
#
# See the pam_unix manpage for other options.


# check for password complexity
password        requisite       pam_pwquality.so retry=3
# here are the per-package modules (the "Primary" block)
password        [success=1 default=ignore]      pam_unix.so sha512 remember=5
# here's the fallback if no module succeeds
password        requisite                       pam_deny.so
# prime the stack with a positive return value if there isn't one already;
# this avoids us returning an error just because nothing sets a success code
# since the modules above will each just jump around
password        required                        pam_permit.so
# and here are more per-package modules (the "Additional" block)
```


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
