### PR TITLE
_FirewallConfig.verify: fix input policy checks

### DIFF
--- a/nilrt_snac/_configs/_firewall_config.py
+++ b/nilrt_snac/_configs/_firewall_config.py
@@ -133,8 +133,8 @@ class _FirewallConfig(_BaseConfig):
             logger.error(f"MISSING: firewall-cmd")
             valid = False
 
-        valid = _check_target("work-in") and valid
+        valid = _check_target("work-in", "CONTINUE") and valid
         valid = _check_target("work-out") and valid
-        valid = _check_target("public-in") and valid
+        valid = _check_target("public-in", "CONTINUE") and valid
         valid = _check_target("public-out") and valid
         return valid


### PR DESCRIPTION
I had changed work-in's and public-in's targets to CONTINUE shortly before posting the PRs, but forgot to update verify() accordingly, so `nilrt-snac verify` started failing. Woops.

### Testing

Verify works.

### Procedure

* [ ] This PR: changes user-visible behavior, fixes a bug, or impacts the project's security profile; and so it includes a [CHANGELOG](https://github.com/ni/nilrt-snac/blob/master/docs/CHANGELOG.md) note.
* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
