### PR TITLE
test_cli: use relative imports for fixtures

### DIFF
--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -3,7 +3,7 @@ from subprocess import CompletedProcess
 import re
 
 from nilrt_snac import __version__
-from tests.integration.fixtures import nilrt_snac_cli
+from .fixtures import nilrt_snac_cli
 
 
 def test_help(nilrt_snac_cli):


### PR DESCRIPTION
### Summary of Changes

The integration tests module isn't really installed like a fully-resolvable module. So we cannot use absolute module paths to import fixtures. Rather, use relative imports.


### Justification

The `test_cli` integration test module fails to import fixtures when called from the ptest-runner in NILRT 10. This is because the module tries to import using `tests.integration.fixtures`, but the `tests/` directory has no `__init__.py` to make it appear like a module. Though adding a `tests/__init__.py` file also fixes this error, it isn't really *correct*, because `tests/` is really a directory of independent source components, rather than a module.

I think the reason this works in NILRT 11 is because of subtle changes in its version of `pytest`, but I'm not 100% sure.

[AB#2867692](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2867692)

### Testing

* [x] Tested on a NILRT kirkstone VM and confirmed that this fixed the import error.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
