### PR TITLE
nilrt-snac configure: create required file, opasswd

### DIFF
--- a/nilrt_snac/_configs/_pwquality_config.py
+++ b/nilrt_snac/_configs/_pwquality_config.py
@@ -14,10 +14,13 @@ class _PWQualityConfig(_BaseConfig):
 
     def configure(self, args: argparse.Namespace) -> None:
         print("Configuring Password quality...")
+        opasswd_file = _ConfigFile("/etc/security/opasswd") # contains password history
         config_file = _ConfigFile("/etc/pam.d/common-password")
         dry_run: bool = args.dry_run
         self._opkg_helper.install("libpwquality")
 
+        if not opasswd_file.exists():
+            opasswd_file.save(dry_run)
         if not config_file.contains("remember=5"):
             config_file.update(r"(password.*pam_unix.so.*)", r"\1 remember=5")
         if not config_file.contains("password.*requisite.*pam_pwquality.so.*retry=3"):


### PR DESCRIPTION
The `remember` option of pam_unix requires the existence of an opasswd file to store the previous passwords.

### Summary of Changes

Create the file, `/etc/security/opasswd`.


### Justification

Without this change, users (other than root) cannot change their password.


### Testing

I ran `nilrt-snac configure` and then was able to log in as a different user and change the user's password.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
