### PR TITLE
Install wireguard-tools from feeds. Fix pythonpath bug.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,10 +94,10 @@ install : all mkinstalldirs $(DIST_FILES)
 	# ni-wireguard-labview
 	install --mode=0660 \
 		src/ni-wireguard-labview/wglv0.conf \
-		"$(DESTDIR)$(sysconfdir)/wireguard"
+		"$(DESTDIR)/etc/wireguard"
 	install --mode=0754 \
 		src/ni-wireguard-labview/ni-wireguard-labview.initd \
-		"$(DESTDIR)$(sysconfdir)/init.d/ni-wireguard-labview"
+		"$(DESTDIR)/etc/init.d/ni-wireguard-labview"
 
 	# install python library
 	for pyfile in $(PYNILRT_SNAC_FILES); do \
@@ -115,8 +115,8 @@ installcheck :
 
 
 mkinstalldirs :
-	mkdir -p --mode=0700 "$(DESTDIR)$(sysconfdir)/wireguard"
-	mkdir -p --mode=0755 "$(DESTDIR)$(sysconfdir)/init.d"
+	mkdir -p --mode=0700 "$(DESTDIR)/etc/wireguard"
+	mkdir -p --mode=0755 "$(DESTDIR)/etc/init.d"
 	mkdir -p "$(DESTDIR)$(datarootdir)/$(PACKAGE)"
 	mkdir -p "$(DESTDIR)$(docdir)/$(PACKAGE)"
 	mkdir -p "$(DESTDIR)$(libdir)/$(PACKAGE)"
@@ -130,6 +130,6 @@ uninstall :
 	rm -rvf "$(DESTDIR)$(libdir)/$(PACKAGE)"
 
 	# files
-	rm -vf "$(DESTDIR)$(sysconfdir)/init.d/ni-wireguard-labview"
-	rm -vf "$(DESTDIR)$(sysconfdir)/wireguard"/wglv0.*
+	rm -vf "$(DESTDIR)/etc/init.d/ni-wireguard-labview"
+	rm -vf "$(DESTDIR)/etc/wireguard"/wglv0.*
 	rm -vf "$(DESTDIR)$(sbindir)/nilrt-snac"

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Then build the project.
 mkdir -p /usr/local/src
 wget 'https://github.com/ni/nilrt-snac/archive/refs/heads/master.tar.gz' -O - | tar xzf - -C /usr/local/src
 cd /usr/local/src/nilrt-snac*
-make install sysconfdir=/etc  # prefix defaults to /usr/local
+make install  # prefix defaults to /usr/local
 ```
 
 ### Uninstallation

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ This tool...
 * requires access to the core NILRT package feeds.
 * can only be run as root.
 * installs some open source projects at runtime which are not officially supported by NI.
-	* wireguard-tools (from the debian package feeds)
 	* USBGuard (from its canonical upstream GH repo)
 
 

--- a/nilrt_snac/_configs/_wireguard_config.py
+++ b/nilrt_snac/_configs/_wireguard_config.py
@@ -24,7 +24,7 @@ class _WireguardConfig(_BaseConfig):
         ifplug_conf = _ConfigFile("/etc/ifplugd/ifplugd.conf")
         dry_run: bool = args.dry_run
 
-        self._opkg_helper.install("wireguard-tools", force_reinstall=True)
+        self._opkg_helper.install("wireguard-tools")
 
         if not ifplug_conf.contains("^ARGS_wglv0.*"):
             ifplug_conf.add(

--- a/nilrt_snac/_configs/_wireguard_config.py
+++ b/nilrt_snac/_configs/_wireguard_config.py
@@ -9,8 +9,6 @@ from nilrt_snac._configs._config_file import _ConfigFile
 from nilrt_snac import logger
 from nilrt_snac.opkg import OPKG_SNAC_CONF, opkg_helper
 
-WIREGUARD_TOOLS_DEB = "http://ftp.us.debian.org/debian/pool/main/w/wireguard/wireguard-tools_1.0.20210914-1+b1_amd64.deb"
-
 
 class _WireguardConfig(_BaseConfig):
     def __init__(self):
@@ -25,13 +23,8 @@ class _WireguardConfig(_BaseConfig):
         opkg_conf = _ConfigFile(OPKG_SNAC_CONF)
         ifplug_conf = _ConfigFile("/etc/ifplugd/ifplugd.conf")
         dry_run: bool = args.dry_run
-        subprocess.run(["wget", WIREGUARD_TOOLS_DEB, "-O", "./wireguard-tools.deb"], check=True)
-        if not opkg_conf.contains("arch amd64 15"):
-            opkg_conf.add("arch amd64 15\n")
-            # We need to save the file before installing the package so that amd64 is
-            # a valid architecture
-            opkg_conf.save(dry_run)
-        self._opkg_helper.install("./wireguard-tools.deb", force_reinstall=True)
+
+        self._opkg_helper.install("wireguard-tools", force_reinstall=True)
 
         if not ifplug_conf.contains("^ARGS_wglv0.*"):
             ifplug_conf.add(

--- a/src/nilrt-snac
+++ b/src/nilrt-snac
@@ -5,4 +5,5 @@ export SCRIPTPATH=$(dirname $0)
 pushd ${SCRIPTPATH} > /dev/null
 export PYTHONSCRIPTPATH=$(realpath ../lib/nilrt-snac)
 popd > /dev/null
-PYTHONPATH=${PYTHONPATH}:${PYTHONSCRIPTPATH} python3 -m nilrt_snac $@
+
+PYTHONPATH=${PYTHONSCRIPTPATH}:${PYTHONPATH} python3 -P -m nilrt_snac $@

--- a/src/nilrt-snac
+++ b/src/nilrt-snac
@@ -6,4 +6,4 @@ pushd ${SCRIPTPATH} > /dev/null
 export PYTHONSCRIPTPATH=$(realpath ../lib/nilrt-snac)
 popd > /dev/null
 
-PYTHONPATH=${PYTHONSCRIPTPATH}:${PYTHONPATH} python3 -P -m nilrt_snac $@
+PYTHONPATH=${PYTHONSCRIPTPATH}:${PYTHONPATH} python3 -P -B -m nilrt_snac $@


### PR DESCRIPTION
### Summary of Changes

* Change the `_wireguard_config` module to install `wireguard-tools` from a native NILRT IPK, rather than from the debian package repos.
* Fix a bug in the `nilrt-snac` wrapper script that caused local paths to pollute module execution and mess with other search paths.


### Justification

[AB#2769306](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2769306)

The path fix is incidental.


### Testing

* [x] Installed these changes to to a local NILRT VM (scarthgap) and tested that the wireguard-tools IPK is now coming from the feeds, and that the script works even when run from a local source checkout of nilrt-snac.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
