### PR TITLE
wireguard_config: remove stale opkg configuration logic

### DIFF
--- a/nilrt_snac/_configs/_wireguard_config.py
+++ b/nilrt_snac/_configs/_wireguard_config.py
@@ -7,7 +7,7 @@ from nilrt_snac._configs._base_config import _BaseConfig
 from nilrt_snac._configs._config_file import _ConfigFile
 
 from nilrt_snac import logger
-from nilrt_snac.opkg import OPKG_SNAC_CONF, opkg_helper
+from nilrt_snac.opkg import opkg_helper
 
 
 class _WireguardConfig(_BaseConfig):
@@ -20,7 +20,6 @@ class _WireguardConfig(_BaseConfig):
         config_file = _ConfigFile(self._sysconnf_path / "wglv0.conf")
         private_key = _ConfigFile(self._sysconnf_path / "wglv0.privatekey")
         public_key = _ConfigFile(self._sysconnf_path / "wglv0.publickey")
-        opkg_conf = _ConfigFile(OPKG_SNAC_CONF)
         ifplug_conf = _ConfigFile("/etc/ifplugd/ifplugd.conf")
         dry_run: bool = args.dry_run
 
@@ -54,7 +53,6 @@ class _WireguardConfig(_BaseConfig):
         config_file.save(dry_run)
         private_key.save(dry_run)
         public_key.save(dry_run)
-        opkg_conf.save(dry_run)
         ifplug_conf.save(dry_run)
         if not dry_run:
             logger.debug("Restating wireguard service")
@@ -83,7 +81,6 @@ class _WireguardConfig(_BaseConfig):
         config_file = _ConfigFile(self._sysconnf_path / "wglv0.conf")
         private_key = _ConfigFile(self._sysconnf_path / "wglv0.privatekey")
         public_key = _ConfigFile(self._sysconnf_path / "wglv0.publickey")
-        opkg_conf = _ConfigFile(OPKG_SNAC_CONF)
         ifplug_conf = _ConfigFile("/etc/ifplugd/ifplugd.conf")
         valid = True
         if not self._opkg_helper.is_installed("wireguard-tools"):
@@ -98,9 +95,6 @@ class _WireguardConfig(_BaseConfig):
         if not public_key.exists():
             valid = False
             logger.error(f"MISSING: {public_key.path}")
-        if not opkg_conf.contains("arch amd64 15"):
-            valid = False
-            logger.error(f"MISSING: 'arch amd64 15' in {opkg_conf.path}")
         if not ifplug_conf.contains("ARGS_wglv0=.*"):
             valid = False
             logger.error(f"MISSING: 'ARGS_wglv0=.*' in {ifplug_conf.path}")


### PR DESCRIPTION
### Summary of Changes

remove stale opkg configuration logic

The logic is a relic of when we were installing wireguard-tools from the debian package. See #36.


### Justification

[AB#2921768](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2921768)

The logic causes `verify` to fail.


### Testing

I ran `nilrt-snac verify`.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
