### PR TITLE
tests/system: add wireguard test fixture

### DIFF
--- a/tests/system/wireguard_fixture/__init__.py
+++ b/tests/system/wireguard_fixture/__init__.py
@@ -1,0 +1,4 @@
+from logging import getLogger
+
+logger = getLogger(__package__)
+

--- a/tests/system/wireguard_fixture/__main__.py
+++ b/tests/system/wireguard_fixture/__main__.py
@@ -99,6 +99,7 @@ def _cmd_setup(
     )
 
     print("Setup DONE.")
+    logger.info(f"Remote IPv4 tunnel address: {str(remote_wg_ip)}")
     return EX.OK
 
 

--- a/tests/system/wireguard_fixture/__main__.py
+++ b/tests/system/wireguard_fixture/__main__.py
@@ -1,0 +1,167 @@
+"""Setup or teardown a wireguard tunnel connection between a windows host and a NILRT+SNAC client's wglv0 interface.
+"""
+import argparse
+from enum import IntEnum
+import logging
+import platform
+import sys
+import ctypes
+from ipaddress import IPv4Interface, IPv4Network
+
+from fabric import Connection
+
+from . import logger
+from .wireguard import WireguardClient
+
+
+LOG_FMT = '%(asctime)s:%(levelname)s:%(name)s:%(filename)s(%(lineno)s): %(message)s'
+TUNNEL_NAME = "nilrt-snac-test"
+TEST_NETWORK = IPv4Network("172.16.128.0/30")
+
+
+class EX(IntEnum):
+    """Process return codes for the main() method."""
+    OK = 0
+    ERROR = 1
+    BADENV = 128
+
+
+def check_administrator(force: bool = False) -> bool:
+    """Check that the script is being executed as "Administrator"."""
+    if force:
+        return True
+
+    try:
+        if ctypes.windll.shell32.IsUserAnAdmin():
+            return True
+        else:
+            logger.error("Script must be run with 'Administrator' privileges.")
+            return False
+    except:
+        return False
+
+
+def check_host_os(force: bool = False) -> bool:
+    """Check that this script is being run on a Windows OS."""
+
+    if platform.system().lower() == "windows":
+        return True
+    elif force:
+        logger.warning("Invalid execution environment (not Windows). Proceeding due to 'force' argument.")
+        return True
+    else:
+        logger.error("Invalid execution environment (not Windows).")
+        return False
+
+
+# MAIN #
+########
+
+def _cmd_setup(
+        args,
+        wg_local: WireguardClient,
+        wg_remote: WireguardClient,
+    ) -> int:
+
+    # tear down any leftover tunnels
+    if _cmd_teardown(args, wg_local, wg_remote) != EX.OK:
+        logger.error(f"Teardown task errored. Bailing out.")
+        return EX.ERROR
+    
+    # pick IPv4 addresses from the test network
+    local_wg_ip = IPv4Interface(f"{TEST_NETWORK[1]}/{TEST_NETWORK.prefixlen}")
+    remote_wg_ip = IPv4Interface(f"{TEST_NETWORK[2]}/{TEST_NETWORK.prefixlen}")
+
+    # collect remote wireguard tunnel info
+    remote_pubkey = wg_remote.get_public_key(args.remote_tunnel)
+    remote_port = wg_remote.get_listen_port(args.remote_tunnel)
+    remote_host = wg_remote.get_client_hostname()
+    wg_remote.add_address(args.remote_tunnel, remote_wg_ip)
+
+    # setup local tunnel
+    wg_local.create_tunnel(TUNNEL_NAME, local_wg_ip, listen_port=51820)
+    local_pubkey = wg_local.get_public_key(TUNNEL_NAME)
+    local_port = wg_local.get_listen_port(TUNNEL_NAME)
+    local_host = wg_local.get_client_hostname()
+    
+    # connect tunnels
+    wg_local.add_peer(
+        TUNNEL_NAME,
+        peer_pubkey=remote_pubkey,
+        allowed_ips=[remote_wg_ip.network],
+        endpoint=f"{remote_host}:{remote_port}"
+    )
+    wg_remote.add_peer(
+        args.remote_tunnel,
+        peer_pubkey=local_pubkey,
+        allowed_ips=[local_wg_ip.network],
+        endpoint=f"{local_host}:{local_port}"
+    )
+
+    print("Setup DONE.")
+    return EX.OK
+
+
+def _cmd_teardown(
+        args,
+        wg_local: WireguardClient,
+        wg_remote: WireguardClient,
+    ) -> int:
+    wg_local.remove_tunnel(TUNNEL_NAME)
+    wg_remote.remove_all_peers(args.remote_tunnel)
+
+    return EX.OK
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(title="Commands", dest="_cmd")
+    common_actions = [  # actions common to all subcommands
+        argparse._StoreTrueAction(["-f", "--force"], "force", help="Ignore safety checks."),
+        argparse._StoreTrueAction(["-d", "--debug"], "debug", help="Show DEBUG level output."),
+        argparse._StoreAction([], "remote_host", required=True),
+        argparse._StoreAction([], "remote_tunnel", nargs="?", default="wglv0"),
+    ]
+
+    sp_setup = subparsers.add_parser("setup")
+    [sp_setup._add_action(a) for a in common_actions]
+    
+    sp_teardown = subparsers.add_parser("teardown")
+    [sp_teardown._add_action(a) for a in common_actions]
+
+    args = parser.parse_args(argv)
+
+    if args._cmd is None:
+        parser.print_help()
+        parser.exit(2)
+
+    if args.debug:
+        logging.basicConfig(level=logging.DEBUG, format=LOG_FMT)
+    else:
+        logging.basicConfig(level=logging.INFO, format=LOG_FMT)
+        
+    logger.debug(args)
+
+    if not check_administrator(args.force):
+        return EX.BADENV
+    if not check_host_os(args.force):
+        return EX.BADENV
+    
+    wg_local = WireguardClient()
+    remote_connection = Connection(
+        host=args.remote_host,
+        connect_kwargs={"password": ""},
+        )
+    wg_remote = WireguardClient(connection=remote_connection)
+    
+    if args._cmd == "setup":
+        return _cmd_setup(args, wg_local, wg_remote)
+    elif args._cmd == "teardown":
+        return _cmd_teardown(args, wg_local, wg_remote)
+    else:
+        raise NotImplementedError()
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))
+

--- a/tests/system/wireguard_fixture/wireguard.py
+++ b/tests/system/wireguard_fixture/wireguard.py
@@ -1,0 +1,348 @@
+"""This module abstracts administration of wireguard configurations across Windows and NILRT, and transparently handles remote administration through SSH.
+"""
+from collections import namedtuple
+from datetime import datetime, timedelta
+from ipaddress import IPv4Address, IPv4Network
+from pathlib import PurePath, PurePosixPath, PureWindowsPath
+from socket import gethostname
+from tempfile import gettempdir
+from time import sleep
+import os
+import platform
+import subprocess as sp
+
+import fabric
+
+from . import logger
+
+
+class WireguardQuickConfig():
+
+    Peer = namedtuple("Peer", ["public_key", "allowed_ips"])
+
+    addresses: list[IPv4Address] = []
+    peers = list[Peer]
+    private_key: str
+    listen_port: int = None
+
+    def __init__(
+        self,
+        addresses: list[IPv4Address] = [],
+        listen_port: int = None,
+        private_key: str = None,
+    ):
+        self.addresses = addresses
+        self.peers = []
+        self.private_key = private_key
+        self.listen_port = listen_port
+
+    def add_peer(self, public_key: str, *allowed_ips):
+        self.peers.append(WireguardQuickConfig.Peer(public_key, allowed_ips))
+
+    def __str__(self):
+        lines = ["[Interface]"]
+        for address in self.addresses:
+            lines.append(f"Address = {str(address)}")
+        lines.append(f"PrivateKey = {self.private_key}")
+        if self.listen_port:
+            lines.append(f"ListenPort = {self.listen_port}")
+        # peers
+        for peer in self.peers:
+            lines.append("\n[Peer]")
+            lines.append(f"PublicKey = {peer.public_key}")
+            lines.append(f"AllowedIPs = {", ".join(str(peer.allowed_ips))}")
+        return "\n".join(lines)
+
+
+
+class WireguardClient():
+
+    config_directory: PurePath
+    connection: fabric.Connection = None
+    platform: str
+    
+    def __init__(
+        self,
+        connection: fabric.Connection = None,
+    ):
+        self.connection = connection
+        if self.connection:
+            self.connection.open()
+
+        self.platform = self.guess_platform()
+        logger.debug(f"Guessed platform: {self.platform}")
+
+    def add_address(
+        self,
+        tunnel_name: str,
+        address: IPv4Address,
+    ):
+        if self.platform == "linux":
+            self._run(f"ip address del {str(address)} dev {tunnel_name}")
+            proc = self._run(f"ip address add {str(address)} dev {tunnel_name}")
+            proc.check_returncode()
+        else:
+            raise NotImplementedError()
+
+    def add_peer(
+        self,
+        tunnel_name: str,
+        peer_pubkey: str,
+        allowed_ips: list[IPv4Network] = [],
+        endpoint: str = None,
+        persistent_keepalive_s: int = None,
+        preshared_key: os.PathLike = None,
+        ):
+            set_args = [peer_pubkey]
+            if len(allowed_ips) > 0:
+                set_args += ["allowed-ips", ",".join([str(ip) for ip in allowed_ips])]
+            if persistent_keepalive_s:
+                set_args += ["persistent-keepalive", str(persistent_keepalive_s)]
+            if endpoint:
+                set_args += ["endpoint", endpoint]
+            if preshared_key:
+                set_args += ["preshared-key", str(preshared_key)]
+            proc = self._run(f"wg set {tunnel_name} peer " + " ".join(set_args))
+            proc.check_returncode()
+
+    def create_tunnel(
+        self,
+        tunnel_name: str,
+        ip_address: str,
+        private_key: str = None,
+        timeout_s: int = 5,
+        listen_port: int = None,
+    ):
+        """Add a new wireguard tunnel to the machine's interfaces.
+        
+        This method asynchronously waits for the interface to come online before returning.
+        
+        Raises: `TimeoutError` when the interface fails to come oneline before `timeout_s` is reached.
+        """
+        if private_key is None:
+            private_key = self.genkey()
+
+        wg_quick_conf = WireguardQuickConfig(
+            addresses = [ip_address],
+            private_key = private_key,
+            listen_port = listen_port,
+        )
+
+        if self.platform == "windows":
+            conf_file = PureWindowsPath(gettempdir()) / (tunnel_name + ".conf")
+            with open(conf_file, 'w+t') as fp_conf:
+                logger.debug(f"Writing conf file: {conf_file}")
+                fp_conf.write(str(wg_quick_conf))
+            proc = self._run(
+                f"wireguard.exe /installtunnelservice \"{conf_file}\"",
+            )
+            proc.check_returncode()
+        elif self.platform == "linux":
+            conf_file = PurePosixPath("/tmp") / (tunnel_name + ".conf")
+            self._run(f"cat >\"{conf_file}\" <<EOF\n{str(wg_quick_conf)}\nEOF", check=True)
+            proc = self._run(f"wg-quick up \"{conf_file}\"")
+            proc.check_returncode()
+        else:
+            raise NotImplementedError()
+        
+        self.wait_on_interface(tunnel_name, timeout_s=timeout_s)
+
+        # add firewall rule for interface
+        if self.platform == "windows":
+            logger.info("Reseting windows firewall rule 'nilrt-snac-test-wg'")
+            proc = self._run("netsh advfirewall firewall delete rule name=nilrt-snac-test-wg")
+            proc = self._run(f"netsh advfirewall firewall add rule name=nilrt-snac-test-wg dir=in action=allow protocol=ANY localip={ip_address} profile=any")
+            proc.check_returncode()
+
+
+    def genkey(self) -> str:
+        """Have wireguard generate a new private key.
+        
+        Returns: The generated private key as a `str`.
+        """
+        proc = self._run("wg genkey")
+        return str(proc.stdout).splitlines()[0].strip()
+    
+    def get_client_hostname(self):
+        """Return the client's ipv4 address."""
+        if self.connection is None:  # local client
+            return gethostname()
+        
+        # remote client
+        return self.connection.transport.getpeername()[0]
+
+    def get_listen_port(self, tunnel_name: str) -> int:
+        """Get the tunnel interface's listen-port attribute."""
+        return int(self.show(tunnel_name, "listen-port"))
+
+    def get_peers(self, tunnel_name: str) -> list[str]:
+        """Return a list of peers, identified by public key."""
+        proc = self._run(f"wg show {tunnel_name} peers")
+        proc.check_returncode()
+
+        peers = []
+        for line in str(proc.stdout).splitlines():
+            line = line.strip()
+            if len(line) == 0:
+                continue
+            peers.append(line)
+        return peers
+
+    def get_public_key(self, tunnel_name: str) -> str:
+        """Get the tunnel interface's public-key attribute."""
+        return self.show(tunnel_name, "public-key").splitlines()[0].strip()
+
+    def guess_platform(self) -> str:
+        """Heuristically determine the platform type that is client is running on.
+        
+        Returns: One of: "windows" or "linux".
+        """
+        # If not running remotely, just have python tell us.
+        if self.connection is None:
+            return platform.system().lower()
+        # Otherwise, interrogate the filesystem.
+        proc = self._run("cat /etc/os-release")
+        if proc.returncode > 0:
+            # probably windows
+            return "windows"
+        else:
+            return "linux"
+        
+    def is_online(self, tunnel_name: str) -> bool:
+        """Check if a wireguard tunnel interface is online (present).
+        
+        Returns: True, if the tunnel interface is present; False otherwise.
+        """
+        proc = self._run(f"wg show {tunnel_name}")
+        if proc.returncode == 0:
+            return True
+        else:
+            return False
+
+    def remove_peer(self, tunnel_name: str, public_key: str):
+        """Remove a peer from the tunnel by pubkey."""
+        proc = self._run(f"wg set {tunnel_name} peer {public_key} remove")
+        if public_key in self.get_peers(tunnel_name):
+            raise RuntimeError(f"Failed to remove peer {public_key} from {tunnel_name}.")
+        
+    def remove_all_peers(self, tunnel_name: str):
+        """Remove all peer definitions for a tunnel."""
+        for peer in self.get_peers(tunnel_name):
+            self.remove_peer(tunnel_name, peer)
+        
+    def remove_tunnel(self, tunnel_name: str):
+        """Remove a tunnel interface from the system."""
+        if not self.is_online(tunnel_name):
+            logger.info(f"Tunnel {tunnel_name} not online. Nothing to do.")
+            return
+        
+        logger.info(f"Removing tunnel {tunnel_name}")
+        if self.platform == "windows":
+            self._run(f"wireguard.exe /uninstalltunnelservice {tunnel_name}")
+        elif self.platform == "linux":
+            self._run(f"wg-quick down {tunnel_name}")
+        else:
+            raise NotImplementedError("Unsupported platform.")
+        self.wait_on_interface(tunnel_name, online=False)
+
+        # add firewall rule for interface
+        if self.platform == "windows":
+            logger.info("Removing windows firewall rule 'nilrt-snac-test-wg'")
+            proc = self._run("netsh advfirewall firewall delete rule name=nilrt-snac-test-wg")
+            proc.check_returncode()
+
+    def _run(
+        self,
+        argv: str | list[str],
+        *args,
+        **kwargs,
+    ) -> sp.CompletedProcess:
+        """Run a shell command either on the local machine, or remotely via SSH.
+
+        Args:
+            argv: Either a shell command string to execute, or a list of shell command arguments.
+        
+        Returns: A subprocess.CompletedProcess object describing the completed process.
+        """
+        if isinstance(argv, list):
+            argv = " ".join(['"' + a + '"' for a in argv])
+        # common defaults
+        kwargs.setdefault("encoding", "utf-8")
+        kwargs.setdefault("timeout", 30)
+
+        if self.connection is None:  # local processes
+            kwargs.setdefault("capture_output", "True")
+            proc = sp.run(argv, shell=True, *args, **kwargs)
+            logger.debug(str(proc))
+            return proc
+
+        if self.connection:  # remote processes
+            invoke_kwargs = {
+                "encoding": kwargs["encoding"],
+                "timeout": kwargs["timeout"],
+                "hide": True,
+                "warn": True,
+            }
+            proc = self.connection.run(argv, **invoke_kwargs)
+            logger.debug(str(proc))
+            if kwargs.get("check", False) and proc.exited > 0:
+                raise sp.CalledProcessError(proc.exited, proc.command, proc.stdout, proc.stderr)
+
+            return sp.CompletedProcess(proc.command, proc.exited, proc.stdout, proc.stderr)
+        
+    def pubkey(self, private_key: str) -> str:
+        """Calculate the public expression of a wireguard private key string.
+        
+        Args:
+            private_key: str. A string representation of the wireguard private key.
+            
+        Returns: The public key expression as a str.
+        """
+        proc = self._run(f"echo {private_key} | wg pubkey")
+        proc.check_returncode()
+        return str(proc.stdout).splitlines()[0].strip()
+    
+    def show(self, tunnel_name: str, attribute: str) -> str:
+        """Return a property of the tunnel interface, as through 'wg show'."""
+        proc = self._run(f"wg show {tunnel_name} {attribute}")
+        proc.check_returncode()
+        return str(proc.stdout)
+    
+    def wait_on_interface(
+            self,
+            tunnel_name: str,
+            online: bool = True,
+            timeout_s: int = 5,
+        ) -> bool:
+        """Asynchronously wait for a wireguard tunnel interface to come online or offline.
+
+        This method uses the 'wg show' command on the backend. If the interface is present, it is "online". If it is missing, it is "offline".
+        
+        Args:
+            tunnel_name: str. The tunnel interface name to wait on.
+            online: bool. If True, wait until the interface comes online. If False, wait until it goes offline.
+            timeout_s: int. The number of seconds to wait, before timing out.
+        
+        Raises: TimeoutError when the interface does not reach the desired state before timeout_s.
+        """
+        if online:
+            print(f"Waiting for tunnel {tunnel_name} to come online.")
+        else:
+            print(f"Waiting for tunnel {tunnel_name} to go offline.")
+
+        def is_correct():
+            if online:
+                return self.is_online(tunnel_name)
+            else:
+                return not self.is_online(tunnel_name)
+
+        found_correct = is_correct()
+        check_start = datetime.now()
+        check_latest = check_start
+        while not found_correct and (check_latest - check_start) < timedelta(seconds=timeout_s):
+            found_correct = is_correct()
+            check_latest = datetime.now()
+            sleep(1)
+        
+        if found_correct == False:
+            raise TimeoutError("Timeout exceeded waiting for interface.")


### PR DESCRIPTION
The wireguard_fixture test module sets up or tears down a wireguard tunnel between a windows LV host and a NILRT client. The script should be run from windows. It uses SSH (via the 'fabric' module) to instrument NILRT-side configuration.

### Summary of Changes

* Add a `tests/system/wireguard_fixture` module that exposes a CLI interface and backing functionality for interacting with wireguard and network interfaces.
* Call `-m wireguard_fixture setup $hostname` to setup a Windows-side tunnel and connect it to the NILRT-side `wglv0` interface.
* Call `-m wireguard_fixture teardown $hostname` to deconfigure the local and remote tunnel.


### Justification

This script is helpful to setup and tear down test environments for labview, to validate that network communication can continue via the wireguard tunnel.

[AB#2905860](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2905860)


### Testing

* [x] Ran this module on a windows host VM, against a cRIO VM in SNAC mode and confirmed that it functioned.
  * Note that interface configuration on Windows and wireguard configuration are both fickle messes and there was at least one instance of tunnel traffic not working, even though everything was configured correctly. It resolved after a night of rest and no changes to the system; no idea why. We'll have to see if this config becomes flakey in the ATS.
  
Normal output looks like this.
```
PS C:\Users\nitest\projects\nilrt-snac\tests\system> python -m wireguard_fixture setup root@10.1.133.111
2024-11-08 11:34:01,660:INFO:paramiko.transport:transport.py(1944): Connected (version 2.0, client OpenSSH_9.6)
2024-11-08 11:34:01,718:INFO:paramiko.transport:transport.py(1944): Auth banner: b'NI Linux Real-Time (run mode)\n\n'
2024-11-08 11:34:01,719:INFO:paramiko.transport:transport.py(1944): Authentication (password) successful!
2024-11-08 11:34:01,798:INFO:wireguard_fixture:wireguard.py(239): Removing tunnel nilrt-snac-test
Waiting for tunnel nilrt-snac-test to go offline.
2024-11-08 11:34:01,954:INFO:wireguard_fixture:wireguard.py(250): Removing windows firewall rule 'nilrt-snac-test-wg'
Waiting for tunnel nilrt-snac-test to come online.
2024-11-08 11:34:04,649:INFO:wireguard_fixture:wireguard.py(152): Reseting windows firewall rule 'nilrt-snac-test-wg'
Setup DONE.
```

Debug output has much more verbose information.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
