### PR TITLE
nilrt-snac: install ni-sysapi-sshcli

### DIFF
--- a/nilrt_snac/_configs/__init__.py
+++ b/nilrt_snac/_configs/__init__.py
@@ -11,6 +11,7 @@ from nilrt_snac._configs._opkg_config import _OPKGConfig
 from nilrt_snac._configs._pwquality_config import _PWQualityConfig
 from nilrt_snac._configs._ssh_config import _SshConfig
 from nilrt_snac._configs._sudo_config import _SudoConfig
+from nilrt_snac._configs._sysapi_config import _SysAPIConfig
 from nilrt_snac._configs._tmux_config import _TmuxConfig
 from nilrt_snac._configs._wifi_config import _WIFIConfig
 from nilrt_snac._configs._wireguard_config import _WireguardConfig
@@ -29,6 +30,7 @@ CONFIGS: List[_BaseConfig] = [
     _FaillockConfig(),
     _X11Config(),
     _ConsoleConfig(),
+    _SysAPIConfig(),
     _TmuxConfig(),
     _PWQualityConfig(),
     _SshConfig(),

--- a/nilrt_snac/_configs/_sysapi_config.py
+++ b/nilrt_snac/_configs/_sysapi_config.py
@@ -1,0 +1,23 @@
+import argparse
+
+from nilrt_snac._configs._base_config import _BaseConfig
+
+from nilrt_snac import logger
+from nilrt_snac.opkg import opkg_helper
+
+
+class _SysAPIConfig(_BaseConfig):
+    def __init__(self):
+        self._opkg_helper = opkg_helper
+
+    def configure(self, args: argparse.Namespace) -> None:
+        print("Configuring SysAPI...")
+        self._opkg_helper.install("ni-sysapi-sshcli")
+
+    def verify(self, args: argparse.Namespace) -> bool:
+        print("Verifying SysAPI configuration...")
+        valid = True
+        if not self._opkg_helper.is_installed("ni-sysapi-sshcli"):
+            valid = False
+            logger.error("MISSING: ni-sysapi-sshcli not installed")
+        return valid


### PR DESCRIPTION
### Summary of Changes

install the `ni-sysapi-sshcli` package during `nilrt-snac configure`


### Justification

System API requires this package in order to communicate from a host to a target over ssh.

[AB#2927009](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2927009)


### Testing

I ran `nilrt-snac configure` and `nilrt-snac verify`.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
