### PR TITLE
Update _x11_config.py to remove packagegroup-ni-graphical

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The dedicated wireguard interface is now called `wglv0` (#6).
 * The `configure` operation now installs `wireguard-tools` configuration files for `wglv0`, so it can persist between reboots (#6).
 * Most of the project's logic has been reimplemented as a python module. (#15).
+* The `configure` operation now removes `packagegroup-ni-graphical` in addition to `packagegroup-core-x11` and `packagegroup-ni-xfce`.
 
 
 ## [0.1.1] - 2024-08-19

--- a/nilrt_snac/_configs/_x11_config.py
+++ b/nilrt_snac/_configs/_x11_config.py
@@ -13,6 +13,7 @@ class _X11Config(_BaseConfig):
     def configure(self, args: argparse.Namespace) -> None:
         print("Removing X11 stack...")
         self._opkg_helper.remove("packagegroup-core-x11")
+        self._opkg_helper.remove("packagegroup-ni-graphical")
         self._opkg_helper.remove("packagegroup-ni-xfce")
         self._opkg_helper.remove("*xfce4*-locale-ja*", ignore_installed=True)  # where do these come from !?!
 
@@ -22,6 +23,9 @@ class _X11Config(_BaseConfig):
         if self._opkg_helper.is_installed("packagegroup-core-x11"):
             valid = False
             logger.error("FOUND: packagegroup-core-x11 installed")
+        if self._opkg_helper.is_installed("packagegroup-ni-graphical"):
+            valid = False
+            logger.error("FOUND: packagegroup-ni-graphical installed")
         if self._opkg_helper.is_installed("packagegroup-ni-xfce"):
             valid = False
             logger.error("FOUND: packagegroup-ni-xfce installed")


### PR DESCRIPTION
### Summary of Changes

Remove the packagegroup-ni-graphical package before removing packagegroup-ni-xfce.

### Justification

When trying to remove packagegroup-ni-xfce, nilrt-snac configure fails with the following error:
```
 * Solver encountered 1 problem(s):
 * Problem 1/1:
 *   - package packagegroup-ni-graphical-1.0-r0.174.x64 requires packagegroup-ni-xfce, but none of the providers can be installed
 *   - conflicting requests
 *   - problem with installed package packagegroup-ni-graphical-1.0-r0.174.x64
 *
 * Solution 1:
 *   - allow deinstallation of packagegroup-ni-graphical-1.0-r0.174.x64

 * Solution 2:
 *   - do not ask to deinstall packagegroup-ni-xfce

 *   - do not ask to deinstall packagegroup-ni-xfce
```

### Testing

On a nilrt VM,
- Ran `nilrt-snac configure --yes`
- Rebooted target
- Ran `nilrt-snac verify`

All operations completed succefully.

### Procedure

* [x] This PR: changes user-visible behavior, fixes a bug, or impacts the project's security profile; and so it includes a [CHANGELOG](https://github.com/ni/nilrt-snac/blob/master/docs/CHANGELOG.md) note.
* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
