### PR TITLE
nilrt-snac config: do not give execute permission to created files

### DIFF
--- a/nilrt_snac/_configs/_config_file.py
+++ b/nilrt_snac/_configs/_config_file.py
@@ -20,7 +20,7 @@ class _ConfigFile:
 
         self.path = path
         self._config = path.read_text() if path.exists() else ""
-        self._mode = path.stat().st_mode if path.exists() else 0o700
+        self._mode = path.stat().st_mode if path.exists() else 0o600
 
     def save(self, dry_run: bool) -> None:
         """Save the configuration file."""


### PR DESCRIPTION
### Summary of Changes

reduce the default file permissions of created files


### Justification

These files don't need execute permission.


### Testing

I ran `nilrt-snac config`.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
