### PR TITLE
Update azure-pipeline.yaml to call mobilize plan

### DIFF
--- a/azure-pipeline.yaml
+++ b/azure-pipeline.yaml
@@ -5,12 +5,12 @@
 
 resources:
   repositories:
-    - repository: DevCentral/ni-central
-      type: git
-      name: ni-central
+  - repository: DevCentral/ni-central
+    type: git
+    name: ni-central
 
 parameters:
-- name: mobilize_ats_pr_build
+- name: rtos_oetest_locked_pr_build
   displayName: 'rtos-oetest-locked PR build number (default: empty)'
   type: string
   default: ' '
@@ -18,9 +18,13 @@ parameters:
 variables:
 - name: BRANCH_NAME
   value: $[replace(variables['Build.SourceBranch'], 'refs/heads/', '')]
+- name: ParamsOutputFile
+  value: $(Build.SourcesDirectory)\snac_pr_params.yaml
+- name: CompiledMobilizePlan
+  value: $(Agent.TempDirectory)/compile_mobilize_plan.yaml
 - template: /src/rtos/pipeline/version.yml@DevCentral/ni-central
 
-trigger:
+pr:
   paths:
     exclude:
     - .github/*
@@ -36,7 +40,7 @@ pool:
   - python3
 
 stages:
-- stage: PrepareBuild
+- stage: BuildInformation
   jobs:
   - job: BuildInformation
     steps:
@@ -54,6 +58,7 @@ stages:
         echo "Build number: $(Build.BuildNumber)" 
         echo "Build ID: $(Build.BuildID)" 
         echo "Build Reason: $(Build.Reason)"
+        echo "Build Sources Directory: $(Build.SourcesDirectory)"
         echo "Build SourceBranch: $(BRANCH_NAME)"
         echo "REPO_EXTERNAL_VERSION_NOSPACE: $(REPO_EXTERNAL_VERSION_NOSPACE)"
         if ("$(Build.Reason)" -eq "PullRequest") {
@@ -67,23 +72,30 @@ stages:
   # Only allow one instance of this stage to run at a time to avoid resource contention issues with the targets used in testing.
   lockBehavior: sequential
   dependsOn:
-  - PrepareBuild
+  - BuildInformation
   jobs:
-  - job: UnitTestforPython
+  - job: SanityTests
     continueOnError: false
     steps:
     - template: /eng/pipeline/python/templates/setup-venv.yml@DevCentral/ni-central
       parameters:
         venvName: test_venv
-        ${{ if ne(parameters.mobilize_ats_pr_build, ' ') }}:
+        ${{ if ne(parameters.rtos_oetest_locked_pr_build, ' ') }}:
           pipPkgs:
-          - rtos-oetest-locked==$(mobilize_ats_pr_build)
+          - rtos-oetest-locked==${{ parameters.rtos_oetest_locked_pr_build }}
           usePRServer: true
         ${{ else }}:
           pipPkgs:
           - rtos-oetest-locked
 
-    - script: |
-          echo "Simulate UnitTest On Python Modules"
-      displayName: SimulateUnitTestOnPython
-      condition: succeeded()
+    - powershell: |
+        $(test_venv.bin_dir)/mako-render $(test_venv.bin_dir)\..\Lib\site-packages\rtos_oetest\mobilize_plans\rtos_oetest\snac\pr\snac_pr_params.yaml.makoo --var majmin_ver="$(Version.Distribution)" --var REPO_VERSION="$(REPO_EXTERNAL_VERSION)" --var REPO_ROOT="$(Build.SourcesDirectory)" --var REPO_EXTERNAL_VERSION_NOSPACE="$(REPO_EXTERNAL_VERSION_NOSPACE)" --output-file $(ParamsOutputFile)
+      displayName: Mako Render Mobilize Params File
+
+    - powershell: |
+        cat $(ParamsOutputFile)
+      displayName: Display Mobilize Params File
+
+    - powershell: |
+        $(test_venv.bin_dir)/mobilize -vv execute -p $(test_venv.bin_dir)\..\Lib\site-packages\rtos_oetest\mobilize_plans\rtos_oetest\snac\pr\snac_pr_provision_and_test.yaml.mako -a $(ParamsOutputFile) -o $(CompiledMobilizePlan)
+      displayName: Execute Mobilize Plan


### PR DESCRIPTION
### Summary of Changes

This commit updates the azure-pipeline.yaml file
to call the mobilize plan that is defined in rtos_oetest.

### Justification

[AB#2903031](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2903031)

### Testing

* [Pipeline run](https://dev.azure.com/ni/DevCentral/_build/results?buildId=11799246&view=logs&j=99c8e54b-67b9-5834-54a1-a3c2d9b921c3&t=99c8e54b-67b9-5834-54a1-a3c2d9b921c3)
* [Mobilize run](https://dashboard.ni.systems/dashboard/#/mobilize?plans=b0e2d532b89a11efb54e010101010000:b0e2d533b89a11efb3e6010101010000)

### Procedure

* [X] This PR: changes user-visible behavior, fixes a bug, or impacts the project's security profile; and so it includes a [CHANGELOG](https://github.com/ni/nilrt-snac/blob/master/docs/CHANGELOG.md) note.
* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
