### PR TITLE
_firewall_config.py: add NI services to default firewall configuration

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The `configure` operation now installs `libpwquality` and enables password quality checks. (#11)
 * The `configure` operation now installs and configures `tmux` as the shell, including adding a 15 minute inactivity lock (#17)
 * Added a `verify` operation to non-destructively check that the system is still SNAC-compliant. (#15)
+* The `configure` operation installs `firewalld` with explicit control over both inbound and outbound
+  traffic. (#29)
+* `firewalld` is configured to permit selected NI service traffic over wireguard. (#50)
 
 ### Changed
 

--- a/nilrt_snac/_configs/_firewall_config.py
+++ b/nilrt_snac/_configs/_firewall_config.py
@@ -90,6 +90,7 @@ class _FirewallConfig(_BaseConfig):
                     "--add-service=https",
                     "--add-service=wireguard",
                     "--add-service=dns",
+                    "--add-service=ntp",
                     )
         _offlinecmd("--policy=public-out", "--set-target=REJECT")
 

--- a/nilrt_snac/_configs/_firewall_config.py
+++ b/nilrt_snac/_configs/_firewall_config.py
@@ -39,6 +39,7 @@ class _FirewallConfig(_BaseConfig):
         self._opkg_helper.install("firewalld")
         self._opkg_helper.install("firewalld-offline-cmd")
         self._opkg_helper.install("firewalld-log-rotate")
+        self._opkg_helper.install("ni-firewalld-servicedefs")
 
         _offlinecmd("--reset-to-defaults")
 
@@ -94,6 +95,14 @@ class _FirewallConfig(_BaseConfig):
                     )
         _offlinecmd("--policy=public-out", "--set-target=REJECT")
 
+        _offlinecmd("--policy=work-in",
+                    "--add-service=ni-labview-realtime",
+                    "--add-service=ni-labview-viserver",
+                    "--add-service=ni-logos-xt",
+                    "--add-service=ni-mxs",
+                    "--add-service=ni-rpc-server",
+                    "--add-service=ni-service-locator",
+                    )
         _offlinecmd("--policy=work-out",
                     "--add-service=amqp",
                     "--add-service=salt-master",

--- a/nilrt_snac/_configs/_firewall_config.py
+++ b/nilrt_snac/_configs/_firewall_config.py
@@ -94,6 +94,11 @@ class _FirewallConfig(_BaseConfig):
                     )
         _offlinecmd("--policy=public-out", "--set-target=REJECT")
 
+        _offlinecmd("--policy=work-out",
+                    "--add-service=amqp",
+                    "--add-service=salt-master",
+                    )
+
         _cmd("--reload")
 
     def verify(self, args: argparse.Namespace) -> bool:


### PR DESCRIPTION
### Summary of Changes

Install ni-firewall-servicedefs to expose NI services to firewalld; enable services for core NI software functionality.

Allow NTP over the public network.

### Testing

`nilrt-snac configure` succeeds; firewall configuration verified manually.

### Procedure

* [X] This PR: changes user-visible behavior, fixes a bug, or impacts the project's security profile; and so it includes a [CHANGELOG](https://github.com/ni/nilrt-snac/blob/master/docs/CHANGELOG.md) note.
* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
