### PR TITLE
Remove development notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 The NI LinuxRT Secured, Network-Attached Controller (SNAC) tool is a utility for admins to put a NILRT system into the SNAC configuration.
 
-NOTICE: This tool is under-development and is very unsafe to run on a production system.
-
 
 # Design
 

--- a/nilrt_snac/__main__.py
+++ b/nilrt_snac/__main__.py
@@ -25,7 +25,6 @@ There is NO WARRANTY, to the extent permitted by law.
 
 def _configure(args: argparse.Namespace) -> int:
     """Configure SNAC mode."""
-    logger.warning("!! THIS TOOL IS IN-DEVELOPMENT AND APPROPRIATE ONLY FOR DEVELOPER TESTING !!")
     logger.warning("!! Running this tool will irreversibly alter the state of your system.    !!")
     logger.warning("!! If you are accessing your system using WiFi, you will lose connection. !!")
 


### PR DESCRIPTION
### Summary of Changes

Remove the notices from the README and __main__.py


### Justification

[AB#2944020](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2944020)

The README and `nilrt-snac configure` workflow warn the user that this tool is in-development. That is no longer true.


### Testing

* None. No time and these should be very safe changes.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
