### PR TITLE
Pin niroco to port 55184 and open it to incoming VPN traffic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ export libdir ?= $(exec_prefix)/lib
 export sbindir ?= $(exec_prefix)/sbin
 export sysconfdir ?= $(prefix)/etc
 
+export nirococonfdir ?= $(datarootdir)/niroco.d
+
 # BINARIES #
 
 export PYTHON ?= python3
@@ -99,6 +101,11 @@ install : all mkinstalldirs $(DIST_FILES)
 		src/ni-wireguard-labview/ni-wireguard-labview.initd \
 		"$(DESTDIR)/etc/init.d/ni-wireguard-labview"
 
+	# firewall configuration pieces
+	install --mode=0644 \
+		src/x-niroco-static-port.ini \
+		"$(DESTDIR)$(nirococonfdir)"
+
 	# install python library
 	for pyfile in $(PYNILRT_SNAC_FILES); do \
 		install -D "$${pyfile}" "$(DESTDIR)$(libdir)/$(PACKAGE)/$${pyfile}"; \
@@ -121,6 +128,7 @@ mkinstalldirs :
 	mkdir -p "$(DESTDIR)$(docdir)/$(PACKAGE)"
 	mkdir -p "$(DESTDIR)$(libdir)/$(PACKAGE)"
 	mkdir -p "$(DESTDIR)$(sbindir)"
+	mkdir -p "$(DESTDIR)$(nirococonfdir)"
 
 
 uninstall :
@@ -133,3 +141,4 @@ uninstall :
 	rm -vf "$(DESTDIR)/etc/init.d/ni-wireguard-labview"
 	rm -vf "$(DESTDIR)/etc/wireguard"/wglv0.*
 	rm -vf "$(DESTDIR)$(sbindir)/nilrt-snac"
+	rm -vf "$(DESTDIR)$(nirococonfdir)/x-niroco-static-port.ini"

--- a/nilrt_snac/_configs/_firewall_config.py
+++ b/nilrt_snac/_configs/_firewall_config.py
@@ -103,6 +103,10 @@ class _FirewallConfig(_BaseConfig):
                     "--add-service=ni-rpc-server",
                     "--add-service=ni-service-locator",
                     )
+        _offlinecmd("--policy=work-in",
+                    # Temporary port add; see x-niroco-static-port.ini
+                    "--add-port=55184/tcp",
+                    )
         _offlinecmd("--policy=work-out",
                     "--add-service=amqp",
                     "--add-service=salt-master",

--- a/src/x-niroco-static-port.ini
+++ b/src/x-niroco-static-port.ini
@@ -1,0 +1,2 @@
+[RemoteServer]
+port=55184


### PR DESCRIPTION
By default, niroco allocates an ephemeral server port, which cannot be effectively firewalled. We can force it to use a specific port with an INI fragment installed to /usr/share/niroco.d, so that _firewall_config.py can allow incoming traffic to that port.

We choose port 55184 more or less entirely arbitrarily, but placing it firmly in the ephemeral range more or less demands that this cannot be the long-term static port decision.

### Testing

`nilrt-snac configure` succeeds and makes the require changes to the firewalld config. New config file added under /usr/share/niroco.d.

### Procedure

* [ ] This PR: changes user-visible behavior, fixes a bug, or impacts the project's security profile; and so it includes a [CHANGELOG](https://github.com/ni/nilrt-snac/blob/master/docs/CHANGELOG.md) note.
* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
