### PR TITLE
Inconsistent handling of --dry-run in different configs.

### DIFF
--- a/nilrt_snac/_configs/_console_config.py
+++ b/nilrt_snac/_configs/_console_config.py
@@ -14,26 +14,29 @@ class _ConsoleConfig(_BaseConfig):
     def configure(self, args: argparse.Namespace) -> None:
         print("Deconfiguring console access...")
 
-        if args.dry_run:
-            return
-
-        subprocess.run(
-            ["nirtcfg", "--set", "section=systemsettings,token=consoleout.enabled,value=False"],
-            check=True,
-        )
+        if not args.dry_run:
+            subprocess.run(
+                ["nirtcfg", "--set", "section=systemsettings,token=consoleout.enabled,value=False"],
+                check=True,
+            )
+        else:
+            print("Dry run: would have run nirtcfg --set section=systemsettings,token=consoleout.enabled,value=False")
         opkg.remove("sysconfig-settings-console", force_depends=True)
 
     def verify(self, args: argparse.Namespace) -> bool:
         print("Verifying console access configuration...")
         valid = True
-        result = subprocess.run(
-            ["nirtcfg", "--get", "section=systemsettings,token=consoleout.enabled"],
-            check=True,
-            stdout=subprocess.PIPE,
-        )
-        if result.stdout.decode().strip() != "False":
-            valid = False
-            logger.error("FOUND: console access not diabled")
+        if not args.dry_run:
+            result = subprocess.run(
+                ["nirtcfg", "--get", "section=systemsettings,token=consoleout.enabled"],
+                check=True,
+                stdout=subprocess.PIPE,
+            )
+            if result.stdout.decode().strip() != "False":
+                valid = False
+                logger.error("FOUND: console access not diabled")
+        else:
+            print("Dry run: would have run nirtcfg --get section=systemsettings,token=consoleout.enabled")
         if opkg.is_installed("sysconfig-settings-console"):
             valid = False
             logger.error("FOUND: sysconfig-settings-console still installed.")

--- a/nilrt_snac/_configs/_graphical_config.py
+++ b/nilrt_snac/_configs/_graphical_config.py
@@ -13,10 +13,11 @@ class _GraphicalConfig(_BaseConfig):
 
     def configure(self, args: Namespace) -> None:
         print("Deconfiguring the graphical UI...")
-        if args.dry_run:
-            return
 
-        run(["nirtcfg", "--set", "section=systemsettings,token=ui.enabled,value=False"], check=True)
+        if not args.dry_run:
+            run(["nirtcfg", "--set", "section=systemsettings,token=ui.enabled,value=False"], check=True)
+        else:
+            print("Dry run: would have run nirtcfg --set section=systemsettings,token=ui.enabled,value=False")
         opkg.remove("packagegroup-ni-graphical", autoremove=True)
         opkg.remove("packagegroup-core-x11", autoremove=True)
 

--- a/nilrt_snac/_configs/_niauth_config.py
+++ b/nilrt_snac/_configs/_niauth_config.py
@@ -19,9 +19,11 @@ class _NIAuthConfig(_BaseConfig):
         if not self._opkg_helper.is_installed("nilrt-snac-conflicts"):
             self._opkg_helper.install(str(SNAC_DATA_DIR / "nilrt-snac-conflicts.ipk"))
 
+        logger.debug("Removing root password")
         if not dry_run:
-            logger.debug("Removing root password")
             subprocess.run(["passwd", "-d", "root"], check=True)
+        else:
+            print("Dry run: would have run passwd -d root")
 
     def verify(self, args: argparse.Namespace) -> bool:
         print("Verifying NIAuth...")

--- a/nilrt_snac/_configs/_ntp_config.py
+++ b/nilrt_snac/_configs/_ntp_config.py
@@ -26,9 +26,11 @@ class _NTPConfig(_BaseConfig):
             config_file.add("server 0.us.pool.ntp.mil iburst maxpoll 16")
 
         config_file.save(dry_run)
+        logger.debug("Restarting ntp service")
         if not dry_run:
-            logger.debug("Restarting ntp service")
             subprocess.run(["/etc/init.d/ntpd", "restart"])
+        else:
+            print("Dry run: would have run /etc/init.d/ntpd restart")
 
     def verify(self, args: argparse.Namespace) -> bool:
         print("Verifying NTP configuration...")

--- a/nilrt_snac/_configs/_opkg_config.py
+++ b/nilrt_snac/_configs/_opkg_config.py
@@ -34,6 +34,8 @@ class _OPKGConfig(_BaseConfig):
             logger.debug("Removing unsupported package feeds...")
             if not dry_run:
                 subprocess.run(["rm", "-fv", "/etc/opkg/NI-dist.conf"], check=True)
+            else:
+                print("Dry run: would have run rm -fv /etc/opkg/NI-dist.conf")
 
         if base_feeds_config_file.contains("src.*/extra/.*"):
             base_feeds_config_file.update("^src.*/extra/.*", "")

--- a/nilrt_snac/_configs/_wifi_config.py
+++ b/nilrt_snac/_configs/_wifi_config.py
@@ -31,10 +31,12 @@ class _WIFIConfig(_BaseConfig):
             )
 
         config_file.save(dry_run)
+        logger.debug("Removing any WiFi modules in memory")
         if not dry_run:
-            logger.debug("Removing any WiFi modules in memory")
             # We do not check for success. If the modules are not loaded, this will return an error
             subprocess.run(["rmmod", "cfg80211", "mac80211"], check=False)
+        else:
+            print("Dry run: would have run rmmod cfg80211 mac80211")
 
     def verify(self, args: argparse.Namespace) -> bool:
         print("Verifying WiFi configuration...")

--- a/nilrt_snac/_configs/_wireguard_config.py
+++ b/nilrt_snac/_configs/_wireguard_config.py
@@ -54,8 +54,8 @@ class _WireguardConfig(_BaseConfig):
         private_key.save(dry_run)
         public_key.save(dry_run)
         ifplug_conf.save(dry_run)
+        logger.debug("Restating wireguard service")
         if not dry_run:
-            logger.debug("Restating wireguard service")
             subprocess.run(
                 [
                     "update-rc.d",
@@ -75,6 +75,9 @@ class _WireguardConfig(_BaseConfig):
                 check=True,
             )
             subprocess.run(["/etc/init.d/ni-wireguard-labview", "restart"], check=True)
+        else:
+            print("Dry run: would have run update-rc.d ni-wireguard-labview start 03 3 4 5 . stop 05 0 6 .")
+            print("Dry run: would have run /etc/init.d/ni-wireguard-labview restart")
 
     def verify(self, args: argparse.Namespace) -> bool:
         print("Verifying wireguard configuration...")


### PR DESCRIPTION
### Summary of Changes
Make the handling of `--dry-run` consistent across the different config types.
* Don't exit `configure()` early
* Print what would have been done if not `--dry-run`
* Add support for `--dry-run` in `validate()` if needed

### Justification

Fixes #46 


### Testing

PR tests


* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
