### PR TITLE
nilrt-snac: fix opkg .conf file permissions

### DIFF
--- a/nilrt_snac/_configs/_opkg_config.py
+++ b/nilrt_snac/_configs/_opkg_config.py
@@ -17,6 +17,7 @@ class _OPKGConfig(_BaseConfig):
     def configure(self, args: argparse.Namespace) -> None:
         print("Configuring opkg...")
         snac_config_file = _ConfigFile(OPKG_SNAC_CONF)
+        snac_config_file.chmod(0o644)
         base_feeds_config_file = _ConfigFile("/etc/opkg/base-feeds.conf")
         dry_run: bool = args.dry_run
 


### PR DESCRIPTION
### Summary of Changes

fix opkg .conf file permissions


### Justification

Standard users need to be able to perform read-only opkg operations.

[AB#2976019](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2976019)


### Testing

I wrote an automated test for this use case.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
