### PR TITLE
[SNAC Audit] Install and configure syslog-ng from SNAC tool

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 * Install and configure `auditd` in order to log system activites.
+* Install and configure `syslog-ng` in order to log system activites.
 
 ### Changed
 * Restricted write access to system logs in `/var/log` to System Maintainers (root) and Auditors via the `adm` group. 

--- a/nilrt_snac/_common.py
+++ b/nilrt_snac/_common.py
@@ -1,4 +1,33 @@
+import grp
+import os
 import pathlib
+import stat
+import subprocess
+
+
+def _check_group_ownership(path: str, group: str) -> bool:
+    "Checks if the group ownership of a file or directory matches the specified group."    
+    stat_info = os.stat(path)
+    gid = stat_info.st_gid
+    group_info = grp.getgrgid(gid)
+
+    return group_info.gr_name == group
+
+def _check_owner(path: str, owner: str) -> bool:
+    "Checks if the owner of a file or directory matches the specified owner."
+    stat_info = os.stat(path)
+    uid = stat_info.st_uid
+    owner_info = grp.getgrgid(uid)
+    return owner_info.gr_name == owner
+
+def _check_permissions(path: str, expected_mode: int) -> bool:
+    "Checks if the permissions of a file or directory match the expected mode."
+    stat_info = os.stat(path)
+    return stat.S_IMODE(stat_info.st_mode) == expected_mode
+
+def _cmd(*args: str):
+    "Syntactic sugar for running shell commands."
+    subprocess.run(args, check=True)
 
 def get_distro():
     try:

--- a/nilrt_snac/_configs/__init__.py
+++ b/nilrt_snac/_configs/__init__.py
@@ -14,6 +14,7 @@ from nilrt_snac._configs._pwquality_config import _PWQualityConfig
 from nilrt_snac._configs._ssh_config import _SshConfig
 from nilrt_snac._configs._sudo_config import _SudoConfig
 from nilrt_snac._configs._sysapi_config import _SysAPIConfig
+from nilrt_snac._configs._syslog_ng_config import _SyslogConfig
 from nilrt_snac._configs._tmux_config import _TmuxConfig
 from nilrt_snac._configs._wifi_config import _WIFIConfig
 from nilrt_snac._configs._wireguard_config import _WireguardConfig
@@ -38,4 +39,5 @@ CONFIGS: List[_BaseConfig] = [
     _SudoConfig(),
     _FirewallConfig(),
     _AuditdConfig(),
+    _SyslogConfig(),
 ]

--- a/nilrt_snac/_configs/_auditd_config.py
+++ b/nilrt_snac/_configs/_auditd_config.py
@@ -3,38 +3,13 @@ import grp
 import os
 import re
 import socket
-import stat
-import subprocess
 from typing import List
 
 from nilrt_snac import logger
 from nilrt_snac._configs._base_config import _BaseConfig
+from nilrt_snac._common import _check_group_ownership, _check_owner, _check_permissions, _cmd
 from nilrt_snac._configs._config_file import EqualsDelimitedConfigFile, _ConfigFile
 from nilrt_snac.opkg import opkg_helper
-
-def _check_group_ownership(path: str, group: str) -> bool:
-    "Checks if the group ownership of a file or directory matches the specified group."    
-    stat_info = os.stat(path)
-    gid = stat_info.st_gid
-    group_info = grp.getgrgid(gid)
-    
-    return group_info.gr_name == group
-
-def _check_owner(path: str, owner: str) -> bool:
-    "Checks if the owner of a file or directory matches the specified owner."
-    stat_info = os.stat(path)
-    uid = stat_info.st_uid
-    owner_info = grp.getgrgid(uid)
-    return owner_info.gr_name == owner
-
-def _check_permissions(path: str, expected_mode: int) -> bool:
-    "Checks if the permissions of a file or directory match the expected mode."
-    stat_info = os.stat(path)
-    return stat.S_IMODE(stat_info.st_mode) == expected_mode
-
-def _cmd(*args: str):
-    "Syntactic sugar for running shell commands."
-    subprocess.run(args, check=True)
 
 def ensure_groups_exist(groups: List[str]) -> None:
     "Ensures the specified groups exist on the system."

--- a/nilrt_snac/_configs/_syslog_ng_config.py
+++ b/nilrt_snac/_configs/_syslog_ng_config.py
@@ -1,0 +1,56 @@
+import argparse
+
+from nilrt_snac import logger
+from nilrt_snac._configs._base_config import _BaseConfig
+from nilrt_snac._configs._config_file import _ConfigFile
+from nilrt_snac._common import _check_group_ownership, _check_owner, _check_permissions, _cmd
+from nilrt_snac.opkg import opkg_helper
+
+
+class _SyslogConfig(_BaseConfig):
+    def __init__(self):
+        self._opkg_helper = opkg_helper
+        self.syslog_conf_path = '/etc/syslog-ng/syslog-ng.conf'
+
+    def configure(self, args: argparse.Namespace) -> None:
+        print("Configuring syslog-ng...")
+        dry_run: bool = args.dry_run
+        if dry_run:
+            return
+
+        # Check if syslog-ng is already installed
+        if not self._opkg_helper.is_installed("syslog-ng"):
+            self._opkg_helper.install("syslog-ng")
+
+        # Enable persistent storage
+        _cmd('nirtcfg', '--set', 'section=SystemSettings,token=PersistentLogs.enabled,value="True"')
+
+        # Restart syslog-ng service
+        _cmd('/etc/init.d/syslog', 'restart')
+
+      
+
+    def verify(self, args: argparse.Namespace) -> bool:
+        print("Verifying syslog-ng configuration...")
+        valid: bool = True
+
+
+        # Check if syslog-ng is setup to log in /var/log
+        if not self._opkg_helper.is_installed("syslog-ng"):
+            logger.error("Required syslog-ng package is not installed.")
+            valid = False
+
+        # Check group ownership and permissions of syslog.conf
+        if not _check_group_ownership(self.syslog_conf_path, "adm"):
+            logger.error(f"ERROR: {self.syslog_conf_path} is not owned by the 'adm' group.")
+            valid = False
+        if not _check_permissions(self.syslog_conf_path, 0o640):
+            logger.error(f"ERROR: {self.syslog_conf_path} does not have 640 permissions.")
+            valid = False
+        if not _check_owner(self.syslog_conf_path, "root"):
+            logger.error(f"ERROR: {self.syslog_conf_path} is not owned by 'root'.")
+            valid = False
+        
+      
+
+        return valid


### PR DESCRIPTION
### Summary of Changes

- Add syslog-ng as a dependency
- Create a test event that verifies events are logging to /var/log

### Justification

800-171 Sections Pertaining to auditing and logging:
https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_171_3_0_0/home?element=SR-03.03.01
https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_171_3_0_0/home?element=SR-03.03.02
https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_171_3_0_0/home?element=SR-03.03.03
https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_171_3_0_0/home?element=SR-03.03.04
https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_171_3_0_0/home?element=SR-03.03.05
https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_171_3_0_0/home?element=SR-03.03.06
https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_171_3_0_0/home?element=SR-03.03.07
https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_171_3_0_0/home?element=SR-03.03.08


### Testing
Manually tested that syslog-ng logs system events to the `/var/log` location.


### Procedure

* [x] This PR: changes user-visible behavior, fixes a bug, or impacts the project's security profile; and so it includes a [CHANGELOG](https://github.com/ni/nilrt-snac/blob/master/docs/CHANGELOG.md) note.
* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
