### PR TITLE
Ensure proper auditd/logging permissions following reboot

### DIFF
--- a/nilrt_snac/_configs/_auditd_config.py
+++ b/nilrt_snac/_configs/_auditd_config.py
@@ -77,7 +77,6 @@ class _AuditdConfig(_BaseConfig):
 
     def configure(self, args: argparse.Namespace) -> None:
         print("Configuring auditd...")
-        auditd_config_file = EqualsDelimitedConfigFile(self.audit_config_path)
         dry_run: bool = args.dry_run
 
         # Check if auditd is already installed
@@ -89,6 +88,7 @@ class _AuditdConfig(_BaseConfig):
         ensure_groups_exist(groups_required)
 
         # Prompt for email if not provided
+        auditd_config_file = EqualsDelimitedConfigFile(self.audit_config_path)
         audit_email = args.audit_email
         unattended_bypass = args.yes
         if not audit_email:

--- a/nilrt_snac/_configs/_syslog_ng_config.py
+++ b/nilrt_snac/_configs/_syslog_ng_config.py
@@ -2,8 +2,7 @@ import argparse
 
 from nilrt_snac import logger
 from nilrt_snac._configs._base_config import _BaseConfig
-from nilrt_snac._configs._config_file import _ConfigFile
-from nilrt_snac._common import _check_group_ownership, _check_owner, _check_permissions, _cmd
+from nilrt_snac._common import _check_owner, _cmd
 from nilrt_snac.opkg import opkg_helper
 
 

--- a/nilrt_snac/_configs/_syslog_ng_config.py
+++ b/nilrt_snac/_configs/_syslog_ng_config.py
@@ -40,13 +40,7 @@ class _SyslogConfig(_BaseConfig):
             logger.error("Required syslog-ng package is not installed.")
             valid = False
 
-        # Check group ownership and permissions of syslog.conf
-        if not _check_group_ownership(self.syslog_conf_path, "adm"):
-            logger.error(f"ERROR: {self.syslog_conf_path} is not owned by the 'adm' group.")
-            valid = False
-        if not _check_permissions(self.syslog_conf_path, 0o640):
-            logger.error(f"ERROR: {self.syslog_conf_path} does not have 640 permissions.")
-            valid = False
+        # Check ownership of syslog.conf
         if not _check_owner(self.syslog_conf_path, "root"):
             logger.error(f"ERROR: {self.syslog_conf_path} is not owned by 'root'.")
             valid = False


### PR DESCRIPTION
### Summary of Changes

- Added permissions script to init.d in order to ensure permissions are set on symlink path
- Moved initialization of audit conf file to ensure file exists
- Added proper permissions for syslog-ng
- Cleaned up unnecessary indentions in script files


### Justification

[Bug 3033025](https://dev.azure.com/ni/DevCentral/_workitems/edit/3033025): nilrt-snac verify fails with error code 129. The verification steps that are failing after reboot:

```
 Stderr:
E           ( 2938) ERROR nilrt_snac.verify: MISSING: expected action_mail_acct value
E           ( 2939) ERROR nilrt_snac.verify: ERROR: /var/volatile/log is not owned by the 'adm' group.
E           ( 2939) ERROR nilrt_snac.verify: ERROR: /var/volatile/log does not have 770 permissions.
E           ( 2939) ERROR nilrt_snac.main: SNAC mode is not configured correctly.
```

### Testing

Tested locally on clean reimaged VM. 


### Procedure

* [x] This PR: changes user-visible behavior, fixes a bug, or impacts the project's security profile; and so it includes a [CHANGELOG](https://github.com/ni/nilrt-snac/blob/master/docs/CHANGELOG.md) note.
* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
