### PR TITLE
Fix verification errors caused by 'contains' function

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Restricted write access to system logs in `/var/log` to System Maintainers (root) and Auditors via the `adm` group. 
 * Restricted write access to `auditd.conf` to System Maintainers and Admins via the `sudo` group.
 
+### Fixed
+* Corrected the `verify` operation to ensure it accurately detects configuration changes.
+
 
 ## [1.0.0] - 2024-12-16
 

--- a/nilrt_snac/_configs/_config_file.py
+++ b/nilrt_snac/_configs/_config_file.py
@@ -83,6 +83,17 @@ class _ConfigFile:
         """
         return bool(re.search(key, self._config))
     
+    def contains_exact(self, key: str) -> bool:
+        """Check if the configuration file contains a line with the exact given key.
+
+        Args: key: RE pattern to search for in the configuration file.
+
+        Returns: True if the key is found, False otherwise.
+        """
+      
+        exact_pattern = re.compile(rf'^\s*{re.escape(key)}\s*$', re.MULTILINE)
+        return bool(exact_pattern.search(self._config))
+    
  
 class EqualsDelimitedConfigFile(_ConfigFile):
     def get(self, key: str) -> str:

--- a/nilrt_snac/_configs/_ntp_config.py
+++ b/nilrt_snac/_configs/_ntp_config.py
@@ -22,7 +22,7 @@ class _NTPConfig(_BaseConfig):
         if config_file.contains("natinst.pool.ntp.org"):
             config_file.update("^.*natinst.pool.ntp.org.*$", "")
 
-        if not config_file.contains("server 0.us.pool.ntp.mil iburst maxpoll 16"):
+        if not config_file.contains_exact("server 0.us.pool.ntp.mil iburst maxpoll 16"):
             config_file.add("server 0.us.pool.ntp.mil iburst maxpoll 16")
 
         config_file.save(dry_run)
@@ -37,7 +37,7 @@ class _NTPConfig(_BaseConfig):
         if not self._opkg_helper.is_installed("ntp"):
             valid = False
             logger.error("MISSING: ntp not installed")
-        if not config_file.contains("0.us.pool.ntp.mil iburst maxpoll 16"):
+        if not config_file.contains_exact("server 0.us.pool.ntp.mil iburst maxpoll 16"):
             valid = False
             logger.error("MISSING: designated ntp server and settings not found in config file")
         if config_file.contains("natinst.pool.ntp.org"):

--- a/nilrt_snac/_configs/_opkg_config.py
+++ b/nilrt_snac/_configs/_opkg_config.py
@@ -21,7 +21,7 @@ class _OPKGConfig(_BaseConfig):
         base_feeds_config_file = _ConfigFile("/etc/opkg/base-feeds.conf")
         dry_run: bool = args.dry_run
 
-        if not snac_config_file.contains("option autoremove 1"):
+        if not snac_config_file.contains_exact("option autoremove 1"):
             snac_config_file.add(
                 textwrap.dedent(
                     """
@@ -51,7 +51,7 @@ class _OPKGConfig(_BaseConfig):
         if not snac_config_file.exists():
             valid = False
             logger.error(f"MISSING: {OPKG_SNAC_CONF} not found")
-        elif not snac_config_file.contains("option autoremove 1"):
+        elif not snac_config_file.contains_exact("option autoremove 1"):
             valid = False
             logger.error(
                 f"MISSING: 'option autoremove 1' not found in {snac_config_file.path}"

--- a/nilrt_snac/_configs/_ssh_config.py
+++ b/nilrt_snac/_configs/_ssh_config.py
@@ -8,10 +8,37 @@ from nilrt_snac import logger
 
 class _SshConfig(_BaseConfig):
     def __init__(self):
-        pass  # Nothing to do for now
+        self.ssh_config_path = "/etc/ssh/sshd_config"
+        self.tmout_config_path = "/etc/profile.d/tmout.sh"
+        self.client_alive_interval = "ClientAliveInterval 15"
+        self.client_alive_count_max = "ClientAliveCountMax 4"
+        self.tmout = "TMOUT=600"
 
     def configure(self, args: argparse.Namespace) -> None:
-        pass  # Nothing to do for now
+        sshd_config_file = _ConfigFile(self.ssh_config_path)
+        tmout_config_file = _ConfigFile(self.tmout_config_path)
+        dry_run: bool = args.dry_run
+
+        if not sshd_config_file.contains_exact(self.client_alive_interval):
+            if sshd_config_file.contains("ClientAliveInterval"):
+                sshd_config_file.update("ClientAliveInterval.*", self.client_alive_interval)
+            else:
+                sshd_config_file.add(self.client_alive_interval)
+        
+        if not sshd_config_file.contains_exact(self.client_alive_count_max):
+            if sshd_config_file.contains("ClientAliveCountMax"):
+                sshd_config_file.update("ClientAliveCountMax.*", self.client_alive_count_max)
+            else:
+                sshd_config_file.add(self.client_alive_count_max)
+        sshd_config_file.save(dry_run)
+
+        if not tmout_config_file.contains_exact(self.tmout):
+            if tmout_config_file.contains("TMOUT"):
+                tmout_config_file.update("TMOUT.*", self.tmout)
+            else:
+                tmout_config_file.add(self.tmout)
+        tmout_config_file.save(dry_run)
+
 
     def verify(self, args: argparse.Namespace) -> bool:
         print("Verifying ssh configuration...")
@@ -21,16 +48,16 @@ class _SshConfig(_BaseConfig):
         if not sshd_config_file.exists():
             valid = False
             logger.error(f"MISSING: {sshd_config_file.path} not found")
-        elif not sshd_config_file.contains_exact("ClientAliveInterval 15"):
+        elif not sshd_config_file.contains_exact(self.client_alive_interval):
             valid = False
             logger.error("MISSING: expected ClientAliveInterval value")
-        elif not sshd_config_file.contains_exact("ClientAliveCountMax 4"):
+        elif not sshd_config_file.contains_exact(self.client_alive_count_max):
             valid = False
             logger.error("MISSING: expected ClientAliveCountMax value")
         if not tmout_config_file.exists():
             valid = False
             logger.error(f"MISSING: {tmout_config_file.path} not found")
-        elif not tmout_config_file.contains_exact("TMOUT=600"):
+        elif not tmout_config_file.contains_exact(self.tmout):
             valid = False
             logger.error("MISSING: expected TMOUT value")
         return valid

--- a/nilrt_snac/_configs/_ssh_config.py
+++ b/nilrt_snac/_configs/_ssh_config.py
@@ -21,16 +21,16 @@ class _SshConfig(_BaseConfig):
         if not sshd_config_file.exists():
             valid = False
             logger.error(f"MISSING: {sshd_config_file.path} not found")
-        elif not sshd_config_file.contains("ClientAliveInterval 15"):
+        elif not sshd_config_file.contains_exact("ClientAliveInterval 15"):
             valid = False
             logger.error("MISSING: expected ClientAliveInterval value")
-        elif not sshd_config_file.contains("ClientAliveCountMax 4"):
+        elif not sshd_config_file.contains_exact("ClientAliveCountMax 4"):
             valid = False
             logger.error("MISSING: expected ClientAliveCountMax value")
         if not tmout_config_file.exists():
             valid = False
             logger.error(f"MISSING: {tmout_config_file.path} not found")
-        elif not tmout_config_file.contains("TMOUT=600"):
+        elif not tmout_config_file.contains_exact("TMOUT=600"):
             valid = False
             logger.error("MISSING: expected TMOUT value")
         return valid

--- a/nilrt_snac/_configs/_sudo_config.py
+++ b/nilrt_snac/_configs/_sudo_config.py
@@ -33,7 +33,7 @@ class _SudoConfig(_BaseConfig):
         if not config_file.exists():
             valid = False
             logger.error(f"MISSING: {config_file.path} not found")
-        elif not config_file.contains("Defaults timestamp_timeout=0"):
+        elif not config_file.contains_exact("Defaults timestamp_timeout=0"):
             valid = False
             logger.error("MISSING: immediate timestamp_timeout")
         return valid

--- a/nilrt_snac/_configs/_tmux_config.py
+++ b/nilrt_snac/_configs/_tmux_config.py
@@ -59,7 +59,7 @@ class _TmuxConfig(_BaseConfig):
         if not snac_config_file.exists():
             valid = False
             logger.error(f"MISSING: {snac_config_file.path} not found")
-        elif not snac_config_file.contains("set -g lock-after-time"):
+        elif not snac_config_file.contains_exact("set -g lock-after-time 900"):
             valid = False
             logger.error("MISSING: commands to inactivity lock")
         if not profile_file.exists():

--- a/nilrt_snac/_configs/_wifi_config.py
+++ b/nilrt_snac/_configs/_wifi_config.py
@@ -16,7 +16,7 @@ class _WIFIConfig(_BaseConfig):
         print("Configuring WiFi configuration...")
         config_file = _ConfigFile("/etc/modprobe.d/snac_blacklist.conf")
         dry_run: bool = args.dry_run
-        if not config_file.contains("install cfg80211 /bin/true"):
+        if not config_file.contains_exact("install cfg80211 /bin/true"):
             config_file.add(
                 textwrap.dedent(
                     """
@@ -43,7 +43,7 @@ class _WIFIConfig(_BaseConfig):
         if not config_file.exists():
             valid = False
             logger.error(f"MISSING: {config_file.path} not found")
-        elif not config_file.contains("install cfg80211 /bin/true"):
+        elif not config_file.contains_exact("install cfg80211 /bin/true"):
             valid = False
             logger.error("MISSING: commands to fail install of WiFi modules")
         return valid


### PR DESCRIPTION
### Summary of Changes

- Added a contains_exact function to address uncaught errors in verification caused by only checking for substrings in the original contains function.
- Reviewed and updated all instances of the contains function in the nilrt-snac package to ensure proper usage.

### Justification

As stated in the [bug](https://dev.azure.com/ni/DevCentral/_boards/board/t/PRnD%20Security/Work%20Items?System.AssignedTo=eli.engelhardt%40emerson.com&workitem=2995040), the 'contains' function in` _config_file.py` only checks for substring which would allow for improper verification. For example, the nilrt-snac configuration puts in the following entry: **ClientAliveCountMax 4**

However if the user changes it, `nilrt-snac verify` wouldn't throw an error for something like this: **ClientAliveCountMax 40**, which is not the behavior we want.

### Testing

Tested whether exact and non-exact string matches have acceptable behaviors for each modified configuration file.


### Procedure

* [x] This PR: changes user-visible behavior, fixes a bug, or impacts the project's security profile; and so it includes a [CHANGELOG](https://github.com/ni/nilrt-snac/blob/master/docs/CHANGELOG.md) note.
* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
