### PR TITLE
_auditd_config.py: fix init script so that it gets run by init

### DIFF
--- a/nilrt_snac/_configs/_auditd_config.py
+++ b/nilrt_snac/_configs/_auditd_config.py
@@ -151,7 +151,7 @@ class _AuditdConfig(_BaseConfig):
 
         # Set the appropriate permissions to allow only root and the 'adm' group to write/read
         init_log_permissions_path = '/etc/init.d/set_log_permissions.sh'
-        if not os.path.exists(init_log_permissions_path):
+        if not os.path.exists(init_log_permissions_path) and not dry_run:
             init_log_permissions_script = textwrap.dedent("""\
             #!/bin/sh
             chmod 770 {log_path}
@@ -165,6 +165,9 @@ class _AuditdConfig(_BaseConfig):
 
             # Make the script executable
             _cmd("chmod", "700", init_log_permissions_path)
+
+            # Schedule the script to run at start
+            _cmd(*"update-rc.d set_log_permissions.sh start 3 S .".split())
 
 
     def verify(self, args: argparse.Namespace) -> bool:


### PR DESCRIPTION
### Summary of Changes

call update-rc.d so the init script actually gets run by init


### Justification

The init script wasn't running on boot, which results in a failure at `verify`.

AB#3033025


### Testing

I ran `nilrt-snac configure`, then `reboot`, then `nilrt-snac verify`.


### Procedure

* [ ] This PR: changes user-visible behavior, fixes a bug, or impacts the project's security profile; and so it includes a [CHANGELOG](https://github.com/ni/nilrt-snac/blob/master/docs/CHANGELOG.md) note.
* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
