### PR TITLE
_firewall_config.py: add syslog service to work-out policy

### DIFF
--- a/nilrt_snac/_configs/_firewall_config.py
+++ b/nilrt_snac/_configs/_firewall_config.py
@@ -91,6 +91,7 @@ class _FirewallConfig(_BaseConfig):
                     "--add-service=ssh",
                     "--add-service=http",
                     "--add-service=https",
+                    "--add-service=syslog",
                     )
         _offlinecmd("--policy=work-out", "--set-target=REJECT")
 


### PR DESCRIPTION
### Summary of Changes

add syslog service to work-out firewalld policy


### Justification

Users performing remote logging might use this service.


### Testing

[AB#2870419](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2870419)


### Procedure

* [ ] This PR: changes user-visible behavior, fixes a bug, or impacts the project's security profile; and so it includes a [CHANGELOG](https://github.com/ni/nilrt-snac/blob/master/docs/CHANGELOG.md) note.
* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
