### PR TITLE
_auditd_config.py: do not check permissions on file that doesn't exist

### DIFF
--- a/nilrt_snac/_common.py
+++ b/nilrt_snac/_common.py
@@ -6,7 +6,7 @@ import subprocess
 
 
 def _check_group_ownership(path: str, group: str) -> bool:
-    "Checks if the group ownership of a file or directory matches the specified group."    
+    "Checks if the group ownership of a file or directory matches the specified group."
     stat_info = os.stat(path)
     gid = stat_info.st_gid
     group_info = grp.getgrgid(gid)

--- a/nilrt_snac/_configs/_auditd_config.py
+++ b/nilrt_snac/_configs/_auditd_config.py
@@ -182,20 +182,21 @@ class _AuditdConfig(_BaseConfig):
         if not auditd_config_file.exists():
             valid = False
             logger.error(f"MISSING: {auditd_config_file.path} not found")
-        elif not is_valid_email(auditd_config_file.get("action_mail_acct")):
-            valid = False
-            logger.error("MISSING: expected action_mail_acct value")
+        else:
+            if not is_valid_email(auditd_config_file.get("action_mail_acct")):
+                valid = False
+                logger.error("MISSING: expected action_mail_acct value")
 
-        # Check group ownership and permissions of auditd.conf
-        if not _check_group_ownership(self.audit_config_path, "sudo"):
-            logger.error(f"ERROR: {self.audit_config_path} is not owned by the 'sudo' group.")
-            valid = False
-        if not _check_permissions(self.audit_config_path, 0o660):
-            logger.error(f"ERROR: {self.audit_config_path} does not have 660 permissions.")
-            valid = False
-        if not _check_owner(self.audit_config_path, "root"):
-            logger.error(f"ERROR: {self.audit_config_path} is not owned by 'root'.")
-            valid = False
+            # Check group ownership and permissions of auditd.conf
+            if not _check_group_ownership(self.audit_config_path, "sudo"):
+                logger.error(f"ERROR: {self.audit_config_path} is not owned by the 'sudo' group.")
+                valid = False
+            if not _check_permissions(self.audit_config_path, 0o660):
+                logger.error(f"ERROR: {self.audit_config_path} does not have 660 permissions.")
+                valid = False
+            if not _check_owner(self.audit_config_path, "root"):
+                logger.error(f"ERROR: {self.audit_config_path} is not owned by 'root'.")
+                valid = False
 
         # Check group ownership and permissions of /var/log
         if not _check_group_ownership(self.log_path, "adm"):


### PR DESCRIPTION
### Summary of Changes

avoid FileNotFoundError exception when running `verify` before `configure`


### Justification

If `/etc/audit/auditd.conf` doesn't exist, then `verify` will print a stack trace and return error 1 rather than `EX_CHECK_FAILURE`.

[AB#3067833](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3067833)


### Testing

I ran `nilrt-snac verify`.


### Procedure

* [ ] This PR: changes user-visible behavior, fixes a bug, or impacts the project's security profile; and so it includes a [CHANGELOG](https://github.com/ni/nilrt-snac/blob/master/docs/CHANGELOG.md) note.
* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
