### PR TITLE
_firewall_config.py: add ni-logos-xt service to work-out policy

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+* ni-logos-xt outbound traffic is now permitted on the firewall's 'work' zone. (#66)
+
 
 ## [2.1.0] - 2025-06-12
 

--- a/nilrt_snac/_configs/_firewall_config.py
+++ b/nilrt_snac/_configs/_firewall_config.py
@@ -92,6 +92,7 @@ class _FirewallConfig(_BaseConfig):
                     "--add-service=http",
                     "--add-service=https",
                     "--add-service=syslog",
+                    "--add-service=ni-logos-xt",
                     )
         _offlinecmd("--policy=work-out", "--set-target=REJECT")
 


### PR DESCRIPTION
### Summary of Changes

Add ni-logos-xt service to work-out firewalld policy.

### Justification

Our current policy only allows _incoming_ LogosXT-based traffic, i.e. the traffic for features such as Shared Variables and Network Streams. This allows a remote host to access, e.g., an RT target-hosted Shared Variable. However, a remotely hosted Shared Variable is not accessible to a SNAC-enabled RT target. Allowing _outgoing_ traffic on these ports fixes this.
See [AB3122615](https://dev.azure.com/ni/DevCentral/_workitems/edit/3122615/) for more details.

### Testing

- Ran `make install` and `make installcheck` against this change.
- Got the failing Shared Variable test to pass by manually adding the following entries to the firewall:
  - `firewall-cmd --policy=work-out --add-port=2343/tcp`
  - `firewall-cmd --policy=work-out --add-port=59111/tcp`
- Will run Shared Variable and Network Streams tests after merging.

### Procedure

* [x] This PR: changes user-visible behavior, fixes a bug, or impacts the project's security profile; and so it includes a [CHANGELOG](https://github.com/ni/nilrt-snac/blob/master/docs/CHANGELOG.md) note.
* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
