### PR TITLE
Add USBGuard configuration support, remove configuration support and add verification

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 * ni-logos-xt outbound traffic is now permitted on the firewall's 'work' zone. (#66)
+* `usbguard` configuration is verified when installed - requires manual installation (#68)
 
 
 ## [2.1.0] - 2025-06-12

--- a/nilrt_snac/_configs/__init__.py
+++ b/nilrt_snac/_configs/__init__.py
@@ -18,9 +18,7 @@ from nilrt_snac._configs._syslog_ng_config import _SyslogConfig
 from nilrt_snac._configs._tmux_config import _TmuxConfig
 from nilrt_snac._configs._wifi_config import _WIFIConfig
 from nilrt_snac._configs._wireguard_config import _WireguardConfig
-
-# USBGuard is not supported for 1.0, but may be added in the future
-# from nilrt_snac._configs._usbguard_config import _USBGuardConfig
+from nilrt_snac._configs._usbguard_config import _USBGuardConfig
 
 CONFIGS: List[_BaseConfig] = [
     _NTPConfig(),
@@ -40,4 +38,5 @@ CONFIGS: List[_BaseConfig] = [
     _FirewallConfig(),
     _AuditdConfig(),
     _SyslogConfig(),
+    _USBGuardConfig(),
 ]

--- a/nilrt_snac/_configs/_config_file.py
+++ b/nilrt_snac/_configs/_config_file.py
@@ -97,9 +97,17 @@ class _ConfigFile:
  
 class EqualsDelimitedConfigFile(_ConfigFile):
     def get(self, key: str) -> str:
-        value_pattern = rf"{key}\s*=\s*(.*)"
-        match = re.search(value_pattern, self._config)
-        if match:
-            return match.group(1).strip()
-        else:
-            return ""
+        """
+        Return the value for the first line where the left side of '=' matches the key (ignoring whitespace).
+
+        Args:
+            key: The key to search for (left side of equals).
+
+        Returns:
+            The value (right side of equals) for the first matching line, or an empty string if not found.
+        """
+        for line in self._config.splitlines():
+            parts = line.split("=", 1)
+            if len(parts) > 1 and parts[0].replace(" ","").replace("\t","") == key:
+                return parts[1].strip()
+        return ""


### PR DESCRIPTION
### Summary of Changes

* Enable `usbguard_config`
* Remove configuration since it must be installed and configured manually
* Implement verification
    * Only verify when usbguard is installed
    * Verify /etc/usbguard/rules.conf exists and is not empty
* Change `EqualsDelimitedConfigFile.get()` to handle comments
    *  This allows use for USBGuard


### Justification

[AB#3094079](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3094079)


### Testing

* Ran with and without usbguard installed
* Verified missing, empty and non-empty rules.conf files returned expected results


### Procedure

* [X] This PR: changes user-visible behavior, fixes a bug, or impacts the project's security profile; and so it includes a [CHANGELOG](https://github.com/ni/nilrt-snac/blob/master/docs/CHANGELOG.md) note.
* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
