### PR TITLE
Enhance USBGuard verification by adding checks for group ownership, permissions, and owner of the rules file

### DIFF
--- a/nilrt_snac/_configs/_usbguard_config.py
+++ b/nilrt_snac/_configs/_usbguard_config.py
@@ -2,6 +2,7 @@ import argparse
 import pathlib
 
 from nilrt_snac._configs._base_config import _BaseConfig
+from nilrt_snac._common import _check_group_ownership, _check_owner, _check_permissions
 from nilrt_snac._configs._config_file import EqualsDelimitedConfigFile
 
 from nilrt_snac import logger
@@ -36,13 +37,23 @@ class _USBGuardConfig(_BaseConfig):
                 return False
             rules_file = pathlib.Path(rule_file_path)
             if not rules_file.exists():
-                logger.error(f"USBGuard rules file missing: {rules_file_path}")
+                logger.error(f"USBGuard rules file missing: {rules_file}")
                 return False
             if rules_file.stat().st_size == 0:
-                logger.error(f"USBGuard rules file is empty: {rules_file_path}")
+                logger.error(f"USBGuard rules file is empty: {rules_file}")
                 return False
+            # Check group ownership and permissions of rules.conf
+            if not _check_group_ownership(str(rules_file), "root"):
+                logger.error(f"ERROR: {rules_file} is not owned by the 'root' group.")
+                return False
+            if not _check_permissions(str(rules_file), 0o640):
+                logger.error(f"ERROR: {rules_file} does not have 640 permissions.")
+                return False
+            if not _check_owner(str(rules_file), "root"):
+                logger.error(f"ERROR: {rules_file} is not owned by 'root'.")
+                return False
+
             return True
         else:
             print("USBGuard is not installed; skipping verification.")
             return True
-


### PR DESCRIPTION
### Summary of Changes

* Additional checks for owner and permissions
* Fix wrong variable used in error case

### Justification

[AB#3094079](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3094079)


### Testing

Build Locally and tested on snac configured targer


### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
