### PR TITLE
SNAC v3.0.0 Release

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,9 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0] - 2025-09-18
+
+Release corresponding to the LV 2025Q4 / NILRT 11.3 release.
+
+### Added
+* When `usbguard` is installed to the NILRT system, `nilrt-snac verify` will now verify that it is enabled and has a valid configuration. (#68)
+
 ### Changed
 * ni-logos-xt outbound traffic is now permitted on the firewall's 'work' zone. (#66)
-* `usbguard` configuration is verified when installed - requires manual installation (#68)
 
 
 ## [2.1.0] - 2025-06-12

--- a/nilrt_snac/__init__.py
+++ b/nilrt_snac/__init__.py
@@ -4,7 +4,7 @@ import logging
 import pathlib
 from enum import IntEnum
 
-__version__ = "2.0.0"
+__version__ = "3.0.0"
 
 SNAC_DATA_DIR = pathlib.Path(__file__).resolve().parents[3] / "share" / "nilrt-snac"
 


### PR DESCRIPTION
### Summary of Changes

* Update CHANGELOG.
* Update module version.


### Justification

LabVIEW 2025Q4 release.


### Testing

* [x] Installed this PR build of nilrt-snac to a cRIO-9049 2025Q4 BSI, ran `configure` and `verify` and confirmed that everything still works and that the reported version of `nilrt-snac` is now v3.0.0.