### PR TITLE
fix(syslog): add logrotate 'su root adm' directive

### DIFF
--- a/nilrt_snac/_configs/_syslog_ng_config.py
+++ b/nilrt_snac/_configs/_syslog_ng_config.py
@@ -2,6 +2,7 @@ import argparse
 
 from nilrt_snac import logger
 from nilrt_snac._configs._base_config import _BaseConfig
+from nilrt_snac._configs._config_file import _ConfigFile
 from nilrt_snac._common import _check_owner, _cmd
 from nilrt_snac.opkg import opkg_helper
 
@@ -11,6 +12,9 @@ class _SyslogConfig(_BaseConfig):
         super().__init__("syslog")
         self._opkg_helper = opkg_helper
         self.syslog_conf_path = "/etc/syslog-ng/syslog-ng.conf"
+        self.logrotate_conf_path = "/etc/logrotate.conf"
+        self.logrotate_dmesg_conf_path = "/etc/logrotate-dmesg.conf"
+        self.logrotate_su_directive = "su root adm"
 
     def configure(self, args: argparse.Namespace) -> None:
         print("Configuring syslog-ng...")
@@ -19,6 +23,24 @@ class _SyslogConfig(_BaseConfig):
         # Check if syslog-ng is already installed
         if not self._opkg_helper.is_installed("syslog-ng"):
             self._opkg_helper.install("syslog-ng")
+
+        logrotate_conf = _ConfigFile(self.logrotate_conf_path)
+        if logrotate_conf.exists() and not logrotate_conf.contains(self.logrotate_su_directive):
+            logger.debug("Adding 'su root adm' directive to logrotate.conf...")
+            logrotate_conf.update(
+                r"(include\s+/etc/logrotate\.d)",
+                f"{self.logrotate_su_directive}\n\n\\g<1>",
+            )
+            logrotate_conf.save(dry_run)
+
+        logrotate_dmesg_conf = _ConfigFile(self.logrotate_dmesg_conf_path)
+        if logrotate_dmesg_conf.exists() and not logrotate_dmesg_conf.contains(self.logrotate_su_directive):
+            logger.debug("Adding 'su root adm' directive to logrotate-dmesg.conf...")
+            logrotate_dmesg_conf.update(
+                r"(\n/var/log/dmesg)",
+                f"\n\n{self.logrotate_su_directive}\n\n\\g<1>",
+            )
+            logrotate_dmesg_conf.save(dry_run)
 
         if not dry_run:
             # Enable persistent storage
@@ -45,6 +67,31 @@ class _SyslogConfig(_BaseConfig):
         # Check ownership of syslog.conf
         if not _check_owner(self.syslog_conf_path, "root"):
             logger.error(f"ERROR: {self.syslog_conf_path} is not owned by 'root'.")
+            valid = False
+
+        # Check that logrotate is configured to use root:adm for rotation
+        logrotate_conf = _ConfigFile(self.logrotate_conf_path)
+        if not logrotate_conf.exists():
+            logger.error(f"MISSING: {self.logrotate_conf_path} not found.")
+            valid = False
+        elif not logrotate_conf.contains(self.logrotate_su_directive):
+            logger.error(
+                f"MISSING: '{self.logrotate_su_directive}' directive not found in "
+                f"{self.logrotate_conf_path}. Logrotate will skip /var/log files "
+                "due to insecure parent directory permissions (root:adm)."
+            )
+            valid = False
+
+        logrotate_dmesg_conf = _ConfigFile(self.logrotate_dmesg_conf_path)
+        if not logrotate_dmesg_conf.exists():
+            logger.error(f"MISSING: {self.logrotate_dmesg_conf_path} not found.")
+            valid = False
+        elif not logrotate_dmesg_conf.contains(self.logrotate_su_directive):
+            logger.error(
+                f"MISSING: '{self.logrotate_su_directive}' directive not found in "
+                f"{self.logrotate_dmesg_conf_path}. Logrotate will skip /var/log/dmesg "
+                "due to insecure parent directory permissions (root:adm)."
+            )
             valid = False
 
         return valid


### PR DESCRIPTION
### Summary of Changes

/var/log is owned root:adm (group-writable), which causes logrotate to skip all log files in that directory with:

  error: skipping "/var/log/..." because parent directory has insecure
  permissions (It's world writable or writable by group which is not
  "root") Set "su" directive in config file to tell logrotate which
  user/group should be used for rotation.

Fix by inserting 'su root adm' into /etc/logrotate.conf before the include /etc/logrotate.d line, and into /etc/logrotate-dmesg.conf before the /var/log/dmesg stanza, during syslog configure. This tells logrotate to run as root:adm, which has the necessary permissions to safely rotate files under /var/log.

Also add verify checks that the directive is present in both files.

### Justification

[AB#3698573](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3698573)

### Testing

Verified that there is no message at boot and that `logrotate --force` has no errors

### Procedure

* [ ] This PR: changes user-visible behavior, fixes a bug, or impacts the project's security profile; and so it includes a [CHANGELOG](https://github.com/ni/nilrt-snac/blob/master/docs/CHANGELOG.md) note.
* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt-snac/blob/master/docs/CONTRIBUTING.md).
